### PR TITLE
Use HF datasets

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,7 +5,6 @@ directories:
 arguments:
   source_repo_id: remyxai/vqasynth_sample
   target_repo_id: salma-remyx/vqasynth_sample_processed
-  image_col: "image"
+  images: "images"
   include_tags: "Park,Street,Home,Office,Garden,Playground,Warehouse,Shop,Library,Classroom,Kitchen,Living Room,Bedroom,Bathroom,Garage,Balcony,Alley,Sidewalk,Field,Meadow,Tennis court,Driveway,Lobby,Workshop,Gym"
   exclude_tags: "Aerial Photography,Single Subject,Macro Photography,Microscopic Views,Drawings,Unrealistic CGI,Graphs,Charts,Icons,Logos,Text Overlays,Minimalist,Art,Portraits,Close-up shot,Flat Art,Abstract Paintings,Silhouettes,Monochrome Photography,Stock Photos"
-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@ directories:
 
 arguments:
   source_repo_id: remyxai/vqasynth_sample
-  target_repo_id: salma-remyx/vqasynth_sample_processed
-  images: "images"
+  target_repo_name: vqasynth_sample_processed
+  images: "image"
   include_tags: "Park,Street,Home,Office,Garden,Playground,Warehouse,Shop,Library,Classroom,Kitchen,Living Room,Bedroom,Bathroom,Garage,Balcony,Alley,Sidewalk,Field,Meadow,Tennis court,Driveway,Lobby,Workshop,Gym"
   exclude_tags: "Aerial Photography,Single Subject,Macro Photography,Microscopic Views,Drawings,Unrealistic CGI,Graphs,Charts,Icons,Logos,Text Overlays,Minimalist,Art,Portraits,Close-up shot,Flat Art,Abstract Paintings,Silhouettes,Monochrome Photography,Stock Photos"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,11 @@
 # config.yaml
 directories:
-  image_dir: /home/ubuntu/vqasynth_sample
   output_dir: /home/ubuntu/vqasynth_output
 
 arguments:
+  source_repo_id: remyxai/vqasynth_sample
+  target_repo_id: salma-remyx/vqasynth_sample_processed
+  image_col: "image"
   include_tags: "Park,Street,Home,Office,Garden,Playground,Warehouse,Shop,Library,Classroom,Kitchen,Living Room,Bedroom,Bathroom,Garage,Balcony,Alley,Sidewalk,Field,Meadow,Tennis court,Driveway,Lobby,Workshop,Gym"
   exclude_tags: "Aerial Photography,Single Subject,Macro Photography,Microscopic Views,Drawings,Unrealistic CGI,Graphs,Charts,Icons,Logos,Text Overlays,Minimalist,Art,Portraits,Close-up shot,Flat Art,Abstract Paintings,Silhouettes,Monochrome Photography,Stock Photos"
 

--- a/docker/depth_stage/entrypoint.sh
+++ b/docker/depth_stage/entrypoint.sh
@@ -5,7 +5,7 @@ CONFIG_FILE=/app/config/config.yaml
 
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
 SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
-IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
+IMAGES=$(yq e '.arguments.images' $CONFIG_FILE)
 
 # Export these values as environment variables
 export OUTPUT_DIR
@@ -22,7 +22,7 @@ echo "Starting depth processing..."
 python3 process_depth.py \
     --output_dir="${OUTPUT_DIR}" \
     --source_repo_id="${SOURCE_REPO_ID}" \
-    --image_col="${IMAGE_COL}"
+    --images="${IMAGES}"
 
 rm "${OUTPUT_DIR}/filter_done.txt"
 touch "${OUTPUT_DIR}/depth_done.txt"

--- a/docker/depth_stage/entrypoint.sh
+++ b/docker/depth_stage/entrypoint.sh
@@ -3,11 +3,11 @@
 # Parse the config.yaml file using yq or python
 CONFIG_FILE=/app/config/config.yaml
 
-IMAGE_DIR=$(yq e '.directories.image_dir' $CONFIG_FILE)
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
+SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
+IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
 
 # Export these values as environment variables
-export IMAGE_DIR
 export OUTPUT_DIR
 
 echo "Using output directory: $OUTPUT_DIR"
@@ -20,7 +20,9 @@ done
 
 echo "Starting depth processing..."
 python3 process_depth.py \
-    --output_dir="${OUTPUT_DIR}"
+    --output_dir="${OUTPUT_DIR}" \
+    --source_repo_id="${SOURCE_REPO_ID}" \
+    --image_col="${IMAGE_COL}"
 
 rm "${OUTPUT_DIR}/filter_done.txt"
 touch "${OUTPUT_DIR}/depth_done.txt"

--- a/docker/depth_stage/process_depth.py
+++ b/docker/depth_stage/process_depth.py
@@ -4,33 +4,49 @@ import argparse
 import pandas as pd
 import numpy as np
 from PIL import Image
+from vqasynth.datasets import Dataloader
 from vqasynth.depth import DepthEstimator
 
-depth = DepthEstimator()
 
-def main(output_dir):
-    for filename in os.listdir(output_dir):
-        if filename.endswith(".pkl"):
-            pkl_path = os.path.join(output_dir, filename)
-            df = pd.read_pickle(pkl_path)
-            df[["depth_map", "focallength"]] = pd.DataFrame(
-                df.apply(lambda row: depth.run(row["full_path"]), axis=1).tolist(),
-                index=df.index,
-            )
-            df.to_pickle(pkl_path)
-            print(f"Processed and updated {filename}")
+def main(output_dir, source_repo_id, image_col):
+    dataloader = Dataloader(output_dir)
+    depth = DepthEstimator()
+
+    dataset = dataloader.load_dataset(source_repo_id)
+
+    def process_row(example):
+        depth_map, focallength = depth.run(example[image_col])
+        example['depth_map'] = depth_map
+        example['focallength'] = focallength
+        return example
+
+    dataset = dataset.map(process_row)
+    dataloader.save_to_disk(dataset)
+    print("Depth extraction complete")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Process images from .pkl files", add_help=True
+        description="Extract depth from images in dataset", add_help=True
     )
     parser.add_argument(
         "--output_dir",
         type=str,
         required=True,
-        help="path to directory containing .pkl files",
+        help="Path to local dataset cache",
+    )
+    parser.add_argument(
+        "--source_repo_id",
+        type=str,
+        required=True,
+        help="Source huggingface dataset repo id",
+    )
+    parser.add_argument(
+        "--image_col",
+        type=str,
+        required=True,
+        help="Column containing PIL.Image images",
     )
     args = parser.parse_args()
 
-    main(args.output_dir)
+    main(args.output_dir, args.source_repo_id, args.image_col)

--- a/docker/depth_stage/process_depth.py
+++ b/docker/depth_stage/process_depth.py
@@ -8,14 +8,14 @@ from vqasynth.datasets import Dataloader
 from vqasynth.depth import DepthEstimator
 
 
-def main(output_dir, source_repo_id, image_col):
+def main(output_dir, source_repo_id, images):
     dataloader = Dataloader(output_dir)
     depth = DepthEstimator()
 
     dataset = dataloader.load_dataset(source_repo_id)
 
     def process_row(example):
-        depth_map, focallength = depth.run(example[image_col])
+        depth_map, focallength = depth.run(example[images])
         example['depth_map'] = depth_map
         example['focallength'] = focallength
         return example
@@ -42,11 +42,11 @@ if __name__ == "__main__":
         help="Source huggingface dataset repo id",
     )
     parser.add_argument(
-        "--image_col",
+        "--images",
         type=str,
         required=True,
         help="Column containing PIL.Image images",
     )
     args = parser.parse_args()
 
-    main(args.output_dir, args.source_repo_id, args.image_col)
+    main(args.output_dir, args.source_repo_id, args.images)

--- a/docker/embeddings_stage/entrypoint.sh
+++ b/docker/embeddings_stage/entrypoint.sh
@@ -3,18 +3,19 @@
 # Parse the config.yaml file using yq or python
 CONFIG_FILE=/app/config/config.yaml
 
-IMAGE_DIR=$(yq e '.directories.image_dir' $CONFIG_FILE)
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
+SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
+IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
 
 # Export these values as environment variables
-export IMAGE_DIR
 export OUTPUT_DIR
 
 # Start the filtering process
 echo "Starting image embedding extraction process..."
 python3 process_embeddings.py \
-    --image_dir="${IMAGE_DIR}" \
-    --output_dir="${OUTPUT_DIR}"
+    --output_dir="${OUTPUT_DIR}" \
+    --source_repo_id="${SOURCE_REPO_ID}" \
+    --image_col="${IMAGE_COL}"
 
 # Mark filtering as done
 touch "${OUTPUT_DIR}/embeddings_done.txt"

--- a/docker/embeddings_stage/entrypoint.sh
+++ b/docker/embeddings_stage/entrypoint.sh
@@ -5,7 +5,7 @@ CONFIG_FILE=/app/config/config.yaml
 
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
 SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
-IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
+IMAGES=$(yq e '.arguments.images' $CONFIG_FILE)
 
 # Export these values as environment variables
 export OUTPUT_DIR
@@ -15,7 +15,7 @@ echo "Starting image embedding extraction process..."
 python3 process_embeddings.py \
     --output_dir="${OUTPUT_DIR}" \
     --source_repo_id="${SOURCE_REPO_ID}" \
-    --image_col="${IMAGE_COL}"
+    --images="${IMAGES}"
 
 # Mark filtering as done
 touch "${OUTPUT_DIR}/embeddings_done.txt"

--- a/docker/embeddings_stage/process_embeddings.py
+++ b/docker/embeddings_stage/process_embeddings.py
@@ -6,7 +6,7 @@ from PIL import Image
 from vqasynth.datasets import Dataloader
 from vqasynth.embeddings import EmbeddingGenerator
 
-def main(output_dir, source_repo_id, image_col):
+def main(output_dir, source_repo_id, images):
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
@@ -16,7 +16,7 @@ def main(output_dir, source_repo_id, image_col):
     dataset = dataloader.load_dataset(source_repo_id)
 
     def process_row(example):
-        embedding = embedding_generator.run(example[image_col])
+        embedding = embedding_generator.run(example[images])
         example['embedding'] = embedding
         return example
 
@@ -40,10 +40,10 @@ if __name__ == "__main__":
         help="Source huggingface dataset repo id",
     )
     parser.add_argument(
-        "--image_col",
+        "--images",
         type=str,
         required=True,
         help="Column containing PIL.Image images",
     )
     args = parser.parse_args()
-    main(args.output_dir, args.source_repo_id, args.image_col)
+    main(args.output_dir, args.source_repo_id, args.images)

--- a/docker/filter_stage/entrypoint.sh
+++ b/docker/filter_stage/entrypoint.sh
@@ -3,13 +3,12 @@
 # Parse the config.yaml file using yq or python
 CONFIG_FILE=/app/config/config.yaml
 
-IMAGE_DIR=$(yq e '.directories.image_dir' $CONFIG_FILE)
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
+SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
 INCLUDE_TAGS=$(yq e '.arguments.include_tags' $CONFIG_FILE)
 EXCLUDE_TAGS=$(yq e '.arguments.exclude_tags' $CONFIG_FILE)
 
 # Export these values as environment variables
-export IMAGE_DIR
 export OUTPUT_DIR
 
 echo "Using output directory: $OUTPUT_DIR"
@@ -22,6 +21,7 @@ done
 echo "Starting filtering processing..."
 python3 process_filter.py \
     --output_dir="${OUTPUT_DIR}" \
+    --source_repo_id="${SOURCE_REPO_ID}" \
     --include_tags="${INCLUDE_TAGS}" \
     --exclude_tags="${EXCLUDE_TAGS}"
 

--- a/docker/filter_stage/process_filter.py
+++ b/docker/filter_stage/process_filter.py
@@ -20,15 +20,15 @@ def main(output_dir, source_repo_id, include_tags, exclude_tags, confidence_thre
         example['tag'] = tag_filter.get_best_matching_tag(
             example['embedding'], include_tags + exclude_tags
         )
-        example['keep'] = tag_filter.filter_by_tag(
-            example['tag'], include_tags, exclude_tags
-        )
         return example
 
     dataset = dataset.map(process_row)
 
-    dataset_filtered = dataset.filter(lambda example: example['keep'])
-    dataset_filtered = dataset_filtered.remove_columns(['keep'])
+    dataset_filtered = dataset.filter(
+        lambda example: tag_filter.filter_by_tag(
+            example['tag'], include_tags, exclude_tags
+        )
+    )
 
     dataloader.save_to_disk(dataset_filtered)
 

--- a/docker/filter_stage/process_filter.py
+++ b/docker/filter_stage/process_filter.py
@@ -3,42 +3,42 @@ import pickle
 import argparse
 import pandas as pd
 from PIL import Image
+from vqasynth.datasets import Dataloader
 from vqasynth.embeddings import TagFilter
 
-def main(output_dir, include_tags, exclude_tags, confidence_threshold=0.7):
+
+def main(output_dir, source_repo_id, include_tags, exclude_tags, confidence_threshold=0.7):
     tag_filter = TagFilter()
+    dataloader = Dataloader(output_dir)
+
+    dataset = dataloader.load_dataset(source_repo_id)
+
     include_tags = include_tags.strip().split(",")
     exclude_tags = exclude_tags.strip().split(",")
 
-    for filename in os.listdir(output_dir):
-        if filename.endswith(".pkl"):
-            pkl_path = os.path.join(output_dir, filename)
-            df = pd.read_pickle(pkl_path)
+    def process_row(example):
+        example['tag'] = tag_filter.get_best_matching_tag(
+            example['embedding'], include_tags + exclude_tags
+        )
+        example['keep'] = tag_filter.filter_by_tag(
+            example['tag'], include_tags, exclude_tags
+        )
+        return example
 
-            df['tag'] = df.apply(
-                lambda row: tag_filter.get_best_matching_tag(
-                    row['embedding'], include_tags + exclude_tags 
-                ),
-                axis=1
-            )
+    dataset = dataset.map(process_row)
 
-            df['keep'] = df.apply(
-                lambda row: tag_filter.filter_by_tag(
-                    row['tag'], include_tags, exclude_tags
-                ),
-                axis=1
-            )
+    dataset_filtered = dataset.filter(lambda example: example['keep'])
+    dataset_filtered = dataset_filtered.remove_columns(['keep'])
 
-            df_filtered = df[df['keep']]
-            df_filtered = df_filtered.drop(columns=['keep'])
-            df_filtered.to_pickle(pkl_path)
+    dataloader.save_to_disk(dataset_filtered)
 
-            print(f"Processed and updated {filename}, filtered out {len(df) - len(df_filtered)} rows.")
+    print(f"Processed and updated {filename}, filtered out {len(df) - len(df_filtered)} rows.")
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser("Depth extraction", add_help=True)
+    parser = argparse.ArgumentParser("Filter dataset by tags", add_help=True)
     parser.add_argument("--output_dir", type=str, required=True, help="path to output dataset directory")
+    parser.add_argument("--source_repo_id", type=str, required=True, help="Source huggingface dataset repo id")
     parser.add_argument("--include_tags", type=str, required=False, default=None, help="Comma-separated list of tags to include (optional)")
     parser.add_argument("--exclude_tags", type=str, required=False, default=None, help="Comma-separated list of tags to exclude (optional)")
     args = parser.parse_args()
-    main(args.output_dir, args.include_tags, args.exclude_tags)
+    main(args.output_dir, args.source_repo_id, args.include_tags, args.exclude_tags)

--- a/docker/filter_stage/process_filter.py
+++ b/docker/filter_stage/process_filter.py
@@ -32,7 +32,7 @@ def main(output_dir, source_repo_id, include_tags, exclude_tags, confidence_thre
 
     dataloader.save_to_disk(dataset_filtered)
 
-    print(f"Processed and updated {filename}, filtered out {len(df) - len(df_filtered)} rows.")
+    print(f"Dataset filtering complete")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("Filter dataset by tags", add_help=True)

--- a/docker/location_refinement_stage/entrypoint.sh
+++ b/docker/location_refinement_stage/entrypoint.sh
@@ -5,10 +5,9 @@ CONFIG_FILE=/app/config/config.yaml
 
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
 SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
-IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
+IMAGES=$(yq e '.arguments.images' $CONFIG_FILE)
 
 # Export these values as environment variables
-export IMAGE_DIR
 export OUTPUT_DIR
 
 echo "Using output directory: $OUTPUT_DIR"
@@ -22,7 +21,7 @@ echo "Starting location refinement processing..."
 python3 process_location_refinement.py \
     --output_dir="${OUTPUT_DIR}" \
     --source_repo_id="${SOURCE_REPO_ID}" \
-    --image_col="${IMAGE_COL}"
+    --images="${IMAGES}"
 
 rm "${OUTPUT_DIR}/depth_done.txt" 
 touch "${OUTPUT_DIR}/location_refinement_done.txt"

--- a/docker/location_refinement_stage/entrypoint.sh
+++ b/docker/location_refinement_stage/entrypoint.sh
@@ -3,8 +3,9 @@
 # Parse the config.yaml file using yq or python
 CONFIG_FILE=/app/config/config.yaml
 
-IMAGE_DIR=$(yq e '.directories.image_dir' $CONFIG_FILE)
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
+SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
+IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
 
 # Export these values as environment variables
 export IMAGE_DIR
@@ -19,7 +20,9 @@ done
 
 echo "Starting location refinement processing..."
 python3 process_location_refinement.py \
-    --output_dir="${OUTPUT_DIR}"
+    --output_dir="${OUTPUT_DIR}" \
+    --source_repo_id="${SOURCE_REPO_ID}" \
+    --image_col="${IMAGE_COL}"
 
 rm "${OUTPUT_DIR}/depth_done.txt" 
 touch "${OUTPUT_DIR}/location_refinement_done.txt"

--- a/docker/location_refinement_stage/process_location_refinement.py
+++ b/docker/location_refinement_stage/process_location_refinement.py
@@ -8,14 +8,14 @@ from vqasynth.datasets import Dataloader
 from vqasynth.localize import Localizer
 
 
-def main(output_dir, source_repo_id, image_col):
+def main(output_dir, source_repo_id, images):
     dataloader = Dataloader(output_dir)
     localizer = Localizer()
 
     dataset = dataloader.load_dataset(source_repo_id)
 
     def process_row(example):
-        masks, bboxes, captions = localizer.run(example[image_col])
+        masks, bboxes, captions = localizer.run(example[images])
         example['masks'] = masks
         example['bboxes'] = bboxes
         example['captions'] = captions
@@ -43,11 +43,11 @@ if __name__ == "__main__":
         help="Source huggingface dataset repo id",
     )
     parser.add_argument(
-        "--image_col",
+        "--images",
         type=str,
         required=True,
         help="Column containing PIL.Image images",
     )
     args = parser.parse_args()
 
-    main(args.output_dir, args.source_repo_id, args.image_col)
+    main(args.output_dir, args.source_repo_id, args.images)

--- a/docker/location_refinement_stage/process_location_refinement.py
+++ b/docker/location_refinement_stage/process_location_refinement.py
@@ -4,33 +4,50 @@ import random
 import argparse
 import numpy as np
 import pandas as pd
+from vqasynth.datasets import Dataloader
 from vqasynth.localize import Localizer
 
-localizer = Localizer()
 
-def main(output_dir):
-    for filename in os.listdir(output_dir):
-        if filename.endswith(".pkl"):
-            pkl_path = os.path.join(output_dir, filename)
-            df = pd.read_pickle(pkl_path)
-            df[["masks", "bboxes", "captions"]] = pd.DataFrame(
-                df.apply(lambda row: localizer.run(row["image"]), axis=1).tolist(),
-                index=df.index,
-            )
-            df.to_pickle(pkl_path)
-            print(f"Processed and updated {filename}")
+def main(output_dir, source_repo_id, image_col):
+    dataloader = Dataloader(output_dir)
+    localizer = Localizer()
+
+    dataset = dataloader.load_dataset(source_repo_id)
+
+    def process_row(example):
+        masks, bboxes, captions = localizer.run(example[image_col])
+        example['masks'] = masks
+        example['bboxes'] = bboxes
+        example['captions'] = captions
+        return example
+
+    dataset = dataset.map(process_row)
+    dataloader.save_to_disk(dataset)
+    print("Localization complete")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Process images from .pkl files", add_help=True
+        description="Localize and describe objects in images", add_help=True
     )
     parser.add_argument(
         "--output_dir",
         type=str,
         required=True,
-        help="path to directory containing .pkl files",
+        help="Path to local dataset cache",
+    )
+    parser.add_argument(
+        "--source_repo_id",
+        type=str,
+        required=True,
+        help="Source huggingface dataset repo id",
+    )
+    parser.add_argument(
+        "--image_col",
+        type=str,
+        required=True,
+        help="Column containing PIL.Image images",
     )
     args = parser.parse_args()
 
-    main(args.output_dir)
+    main(args.output_dir, args.source_repo_id, args.image_col)

--- a/docker/prompt_stage/entrypoint.sh
+++ b/docker/prompt_stage/entrypoint.sh
@@ -6,7 +6,7 @@ CONFIG_FILE=/app/config/config.yaml
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
 SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
 TARGET_REPO_ID=$(yq e '.arguments.target_repo_id' $CONFIG_FILE)
-IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
+IMAGES=$(yq e '.arguments.images' $CONFIG_FILE)
 
 # Export these values as environment variables
 export OUTPUT_DIR
@@ -24,7 +24,7 @@ python3 process_prompts.py \
     --output_dir="${OUTPUT_DIR}" \
     --source_repo_id="${SOURCE_REPO_ID}" \
     --target_repo_id="${TARGET_REPO_ID}" \
-    --image_col="${IMAGE_COL}"
+    --images="${IMAGES}"
 
 rm "${OUTPUT_DIR}/scene_fusion_done.txt" 
 touch "${OUTPUT_DIR}/data_processing_done.txt"

--- a/docker/prompt_stage/entrypoint.sh
+++ b/docker/prompt_stage/entrypoint.sh
@@ -3,11 +3,12 @@
 # Parse the config.yaml file using yq or python
 CONFIG_FILE=/app/config/config.yaml
 
-IMAGE_DIR=$(yq e '.directories.image_dir' $CONFIG_FILE)
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
+SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
+TARGET_REPO_ID=$(yq e '.arguments.target_repo_id' $CONFIG_FILE)
+IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
 
 # Export these values as environment variables
-export IMAGE_DIR
 export OUTPUT_DIR
 
 echo "Using output directory: $OUTPUT_DIR"
@@ -20,8 +21,10 @@ done
 
 echo "Starting prompt processing..."
 python3 process_prompts.py \
-    --image_dir="${IMAGE_DIR}" \
-    --output_dir="${OUTPUT_DIR}"
+    --output_dir="${OUTPUT_DIR}" \
+    --source_repo_id="${SOURCE_REPO_ID}" \
+    --target_repo_id="${TARGET_REPO_ID}" \
+    --image_col="${IMAGE_COL}"
 
 rm "${OUTPUT_DIR}/scene_fusion_done.txt" 
 touch "${OUTPUT_DIR}/data_processing_done.txt"

--- a/docker/prompt_stage/entrypoint.sh
+++ b/docker/prompt_stage/entrypoint.sh
@@ -5,7 +5,7 @@ CONFIG_FILE=/app/config/config.yaml
 
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
 SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
-TARGET_REPO_ID=$(yq e '.arguments.target_repo_id' $CONFIG_FILE)
+TARGET_REPO_NAME=$(yq e '.arguments.target_repo_name' $CONFIG_FILE)
 IMAGES=$(yq e '.arguments.images' $CONFIG_FILE)
 
 # Export these values as environment variables
@@ -23,7 +23,7 @@ echo "Starting prompt processing..."
 python3 process_prompts.py \
     --output_dir="${OUTPUT_DIR}" \
     --source_repo_id="${SOURCE_REPO_ID}" \
-    --target_repo_id="${TARGET_REPO_ID}" \
+    --target_repo_name="${TARGET_REPO_NAME}" \
     --images="${IMAGES}"
 
 rm "${OUTPUT_DIR}/scene_fusion_done.txt" 

--- a/docker/prompt_stage/process_prompts.py
+++ b/docker/prompt_stage/process_prompts.py
@@ -10,7 +10,7 @@ import pandas as pd
 from vqasynth.datasets import Dataloader
 from vqasynth.prompts import PromptGenerator
 
-def main(output_dir, source_repo_id, target_repo_id, images):
+def main(output_dir, source_repo_id, target_repo_name, images):
     prompt_generator = PromptGenerator()
     dataloader = Dataloader(output_dir)
 
@@ -57,7 +57,7 @@ def main(output_dir, source_repo_id, target_repo_id, images):
     final_dataset = dataset.select_columns([images, "messages"])
 
     dataloader.save_to_disk(final_dataset)
-    dataloader.push_to_hub(final_dataset, target_repo_id)
+    dataloader.push_to_hub(final_dataset, target_repo_name)
 
     print(f"Processed and updated dataset with formatted messages.")
 
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         help="Source huggingface dataset repo id",
     )
     parser.add_argument(
-        "--target_repo_id",
+        "--target_repo_name",
         type=str,
         required=True,
         help="Target huggingface dataset repo id",
@@ -90,4 +90,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    main(args.output_dir, args.source_repo_id, args.target_repo_id, args.images)
+    main(args.output_dir, args.source_repo_id, args.target_repo_name, args.images)

--- a/docker/prompt_stage/process_prompts.py
+++ b/docker/prompt_stage/process_prompts.py
@@ -10,7 +10,7 @@ import pandas as pd
 from vqasynth.datasets import Dataloader
 from vqasynth.prompts import PromptGenerator
 
-def main(output_dir, source_repo_id, target_repo_id, image_col):
+def main(output_dir, source_repo_id, target_repo_id, images):
     prompt_generator = PromptGenerator()
     dataloader = Dataloader(output_dir)
 
@@ -54,7 +54,7 @@ def main(output_dir, source_repo_id, target_repo_id, image_col):
         return example
 
     dataset = dataset.map(process_row)
-    final_dataset = dataset.select_columns([image_col, "messages"])
+    final_dataset = dataset.select_columns([images, "messages"])
 
     dataloader.save_to_disk(final_dataset)
     dataloader.push_to_hub(final_dataset, target_repo_id)
@@ -83,11 +83,11 @@ if __name__ == "__main__":
         help="Target huggingface dataset repo id",
     )
     parser.add_argument(
-        "--image_col",
+        "--images",
         type=str,
         required=True,
         help="Column containing PIL.Image images",
     )
     args = parser.parse_args()
 
-    main(args.output_dir, args.source_repo_id, args.target_repo_id, args.image_col)
+    main(args.output_dir, args.source_repo_id, args.target_repo_id, args.images)

--- a/docker/scene_fusion_stage/entrypoint.sh
+++ b/docker/scene_fusion_stage/entrypoint.sh
@@ -5,7 +5,7 @@ CONFIG_FILE=/app/config/config.yaml
 
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
 SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
-IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
+IMAGES=$(yq e '.arguments.images' $CONFIG_FILE)
 
 # Export these values as environment variables
 export OUTPUT_DIR
@@ -22,7 +22,7 @@ echo "Starting scene_fusion processing..."
 python3 process_scene_fusion.py \
     --output_dir="${OUTPUT_DIR}" \
     --source_repo_id="${SOURCE_REPO_ID}" \
-    --image_col="${IMAGE_COL}"
+    --images="${IMAGES}"
 
 rm "${OUTPUT_DIR}/location_refinement_done.txt" 
 touch "${OUTPUT_DIR}/scene_fusion_done.txt"

--- a/docker/scene_fusion_stage/entrypoint.sh
+++ b/docker/scene_fusion_stage/entrypoint.sh
@@ -3,11 +3,11 @@
 # Parse the config.yaml file using yq or python
 CONFIG_FILE=/app/config/config.yaml
 
-IMAGE_DIR=$(yq e '.directories.image_dir' $CONFIG_FILE)
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
+SOURCE_REPO_ID=$(yq e '.arguments.source_repo_id' $CONFIG_FILE)
+IMAGE_COL=$(yq e '.arguments.image_col' $CONFIG_FILE)
 
 # Export these values as environment variables
-export IMAGE_DIR
 export OUTPUT_DIR
 
 echo "Using output directory: $OUTPUT_DIR"
@@ -20,7 +20,9 @@ done
 
 echo "Starting scene_fusion processing..."
 python3 process_scene_fusion.py \
-    --output_dir="${OUTPUT_DIR}"
+    --output_dir="${OUTPUT_DIR}" \
+    --source_repo_id="${SOURCE_REPO_ID}" \
+    --image_col="${IMAGE_COL}"
 
 rm "${OUTPUT_DIR}/location_refinement_done.txt" 
 touch "${OUTPUT_DIR}/scene_fusion_done.txt"

--- a/docker/scene_fusion_stage/process_scene_fusion.py
+++ b/docker/scene_fusion_stage/process_scene_fusion.py
@@ -6,7 +6,7 @@ from vqasynth.datasets import Dataloader
 from vqasynth.scene_fusion import SpatialSceneConstructor
 
 
-def main(output_dir, source_repo_id, image_col):
+def main(output_dir, source_repo_id, images):
     spatial_scene_constructor = SpatialSceneConstructor()
     dataloader = Dataloader(output_dir)
 
@@ -20,7 +20,7 @@ def main(output_dir, source_repo_id, image_col):
         # Run spatial scene constructor and get point cloud data and canonicalization flag
         pcd_data, canonicalized = spatial_scene_constructor.run(
             str(idx), 
-            example[image_col],
+            example[images],
             example["depth_map"],
             example["focallength"],
             example["masks"],
@@ -50,11 +50,11 @@ if __name__ == "__main__":
         help="Source huggingface dataset repo id",
     )
     parser.add_argument(
-        "--image_col",
+        "--images",
         type=str,
         required=True,
         help="Column containing PIL.Image images",
     )
     args = parser.parse_args()
 
-    main(args.output_dir, args.source_repo_id, args.image_col)
+    main(args.output_dir, args.source_repo_id, args.images)

--- a/docker/scene_fusion_stage/process_scene_fusion.py
+++ b/docker/scene_fusion_stage/process_scene_fusion.py
@@ -2,41 +2,59 @@ import os
 import pickle
 import argparse
 import pandas as pd
+from vqasynth.datasets import Dataloader
 from vqasynth.scene_fusion import SpatialSceneConstructor
 
 
-def main(output_dir):
+def main(output_dir, source_repo_id, image_col):
     spatial_scene_constructor = SpatialSceneConstructor()
+    dataloader = Dataloader(output_dir)
+
+    dataset = dataloader.load_dataset(source_repo_id)
 
     point_cloud_dir = os.path.join(output_dir, "pointclouds")
     if not os.path.exists(point_cloud_dir):
         os.makedirs(point_cloud_dir)
 
-    for filename in os.listdir(output_dir):
-        if filename.endswith('.pkl'):
-            pkl_path = os.path.join(output_dir, filename)
-            df = pd.read_pickle(pkl_path)
+    def process_row(example, idx):
+        # Run spatial scene constructor and get point cloud data and canonicalization flag
+        pcd_data, canonicalized = spatial_scene_constructor.run(
+            str(idx), 
+            example[image_col],
+            example["depth_map"],
+            example["focallength"],
+            example["masks"],
+            output_dir
+        )
+        # Add point cloud data and canonicalization flag to the example
+        example["pointclouds"] = pcd_data
+        example["is_canonicalized"] = canonicalized
+        return example
 
-            # Initialize empty lists to hold the pointclouds and canonicalization flags
-            pointclouds = []
-            is_canonicalized = []
+    dataset = dataset.map(process_row, with_indices=True)
+    dataloader.save_to_disk(dataset)
+    print("Scene fusion complete")
 
-            # Update to process each row and append results to lists
-            for index, row in df.iterrows():
-                pcd_data, canonicalized = spatial_scene_constructor.run(row["image_filename"], row["image"], row["depth_map"], row["focallength"], row["masks"], output_dir)
-                pointclouds.append(pcd_data)
-                is_canonicalized.append(canonicalized)
-
-            # Assign lists to new DataFrame columns
-            df['pointclouds'] = pointclouds
-            df['is_canonicalized'] = is_canonicalized
-
-            df.to_pickle(pkl_path)
-            print(f"Processed and updated {filename}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process images from .pkl files", add_help=True)
-    parser.add_argument("--output_dir", type=str, required=True, help="path to directory containing .pkl files")
+        "--output_dir",
+        type=str,
+        required=True,
+        help="Path to local dataset cache",
+    )
+    parser.add_argument(
+        "--source_repo_id",
+        type=str,
+        required=True,
+        help="Source huggingface dataset repo id",
+    )
+    parser.add_argument(
+        "--image_col",
+        type=str,
+        required=True,
+        help="Column containing PIL.Image images",
+    )
     args = parser.parse_args()
 
-    main(args.output_dir)
+    main(args.output_dir, args.source_repo_id, args.image_col)

--- a/docker/scene_fusion_stage/process_scene_fusion.py
+++ b/docker/scene_fusion_stage/process_scene_fusion.py
@@ -38,6 +38,7 @@ def main(output_dir, source_repo_id, images):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process images from .pkl files", add_help=True)
+    parser.add_argument(
         "--output_dir",
         type=str,
         required=True,

--- a/pipelines/spatialvqa.yaml
+++ b/pipelines/spatialvqa.yaml
@@ -6,10 +6,10 @@ services:
       context: ../
       dockerfile: docker/embeddings_stage/Dockerfile
     volumes:
-      - ${IMAGE_DIR}:${IMAGE_DIR}
       - ${OUTPUT_DIR}:${OUTPUT_DIR}
     environment:
       NVIDIA_VISIBLE_DEVICES: all
+      HF_TOKEN: ${HF_TOKEN}
     deploy:
       resources:
         reservations:
@@ -21,12 +21,12 @@ services:
       context: ../
       dockerfile: docker/filter_stage/Dockerfile
     volumes:
-      - ${IMAGE_DIR}:${IMAGE_DIR}
       - ${OUTPUT_DIR}:${OUTPUT_DIR}
     depends_on:
       - embeddings_stage
     environment:
       NVIDIA_VISIBLE_DEVICES: all
+      HF_TOKEN: ${HF_TOKEN}
     deploy:
       resources:
         reservations:
@@ -38,12 +38,12 @@ services:
       context: ../
       dockerfile: docker/depth_stage/Dockerfile
     volumes:
-      - ${IMAGE_DIR}:${IMAGE_DIR}
       - ${OUTPUT_DIR}:${OUTPUT_DIR}
     depends_on:
       - filter_stage
     environment:
       NVIDIA_VISIBLE_DEVICES: all
+      HF_TOKEN: ${HF_TOKEN}
     deploy:
       resources:
         reservations:
@@ -55,10 +55,12 @@ services:
       context: ../
       dockerfile: docker/location_refinement_stage/Dockerfile
     volumes:
-      - ${IMAGE_DIR}:${IMAGE_DIR}
       - ${OUTPUT_DIR}:${OUTPUT_DIR}
     depends_on:
       - caption_stage
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      HF_TOKEN: ${HF_TOKEN}
     deploy:
       resources:
         reservations:
@@ -70,10 +72,12 @@ services:
       context: ../
       dockerfile: docker/scene_fusion_stage/Dockerfile
     volumes:
-      - ${IMAGE_DIR}:${IMAGE_DIR}
       - ${OUTPUT_DIR}:${OUTPUT_DIR}
     depends_on:
       - location_refinement_stage
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      HF_TOKEN: ${HF_TOKEN}
     deploy:
       resources:
         reservations:
@@ -85,10 +89,12 @@ services:
       context: ../
       dockerfile: docker/prompt_stage/Dockerfile
     volumes:
-      - ${IMAGE_DIR}:${IMAGE_DIR}
       - ${OUTPUT_DIR}:${OUTPUT_DIR}
     depends_on:
       - scene_fusion_stage
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      HF_TOKEN: ${HF_TOKEN}
     deploy:
       resources:
         reservations:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ litellm==1.25.2
 pycocotools==2.0.6
 pandas
 html5lib
+datasets

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 CONFIG_FILE=./config/config.yaml
 
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
-HF_TOKEN=$(cat ~/.huggingface/token)
+HF_TOKEN=$(cat ~/.cache/huggingface/token)
 
 if [ ! -d "$OUTPUT_DIR" ]; then
     echo "Error: Local output directory specified in config.yaml does not exist."

--- a/run.sh
+++ b/run.sh
@@ -2,16 +2,16 @@
 
 CONFIG_FILE=./config/config.yaml
 
-IMAGE_DIR=$(yq e '.directories.image_dir' $CONFIG_FILE)
 OUTPUT_DIR=$(yq e '.directories.output_dir' $CONFIG_FILE)
+HF_TOKEN=$(cat ~/.huggingface/token)
 
-if [ ! -d "$IMAGE_DIR" ] || [ ! -d "$OUTPUT_DIR" ]; then
-    echo "Error: One or both directories specified in config.yaml do not exist."
+if [ ! -d "$OUTPUT_DIR" ]; then
+    echo "Error: Local output directory specified in config.yaml does not exist."
     exit 1
 fi
 
-export IMAGE_DIR="$IMAGE_DIR"
 export OUTPUT_DIR="$OUTPUT_DIR"
+export HF_TOKEN="$HF_TOKEN"
 
 echo "Building base image..."
 docker build -f docker/base_image/Dockerfile -t vqasynth:base .

--- a/vqasynth/datasets.py
+++ b/vqasynth/datasets.py
@@ -1,0 +1,54 @@
+import os
+import logging
+from datasets import load_dataset, load_from_disk, DatasetDict
+from huggingface_hub import HfApi, DatasetCard
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+class Dataloader:
+    def __init__(self, cache_dir):
+        self.cache_dir = cache_dir
+        self.api = HfApi()
+        self.dataset_name = None
+        self.dataset_path = None
+
+    def load_dataset(self, repo_id):
+        """Load dataset from cache or fetch it from Hugging Face Hub."""
+        self.dataset_name = repo_id.split("/")[-1]
+        self.dataset_path = os.path.join(self.cache_dir, self.dataset_name)
+
+        if os.path.exists(self.dataset_path):
+            dataset = load_from_disk(self.dataset_path)
+        else:
+            dataset = load_dataset(repo_id, cache_dir=self.cache_dir)
+            dataset.save_to_disk(self.dataset_path)
+
+        return dataset
+
+    def save_to_disk(self, dataset):
+        """Save a Hugging Face dataset to the cache directory."""
+        try:
+            dataset_path = os.path.join(self.cache_dir, self.dataset_name)
+            dataset.save_to_disk(dataset_path)
+        except Exception as e:
+	    logger.error(f"An error occurred while saving dataset: {str(e)}")
+
+    def _tag_dataset(self, repo_id):
+        card = DatasetCard.load(repo_id)
+        default_tags = ["vqasynth", "remyx"]
+
+        if "tags" not in card.data:
+            card.data["tags"] = default_tags
+        elif not any(tag in card.data["tags"] for tag in default_tags):
+            card.data["tags"].extend(default_tags)
+
+        card.push_to_hub(repo_id)
+
+    def push_to_hub(self, dataset, repo_id):
+        """Push the final dataset to Hugging Face Hub."""
+        try:
+            dataset.push_to_hub(repo_id)
+            self._tag_dateset(repo_id)
+        except Exception as e:
+            logger.error(f"An error occurred while pushing to Hugging Face Hub: {str(e)}")

--- a/vqasynth/datasets.py
+++ b/vqasynth/datasets.py
@@ -45,9 +45,10 @@ class Dataloader:
 
         card.push_to_hub(repo_id)
 
-    def push_to_hub(self, dataset, repo_id):
+    def push_to_hub(self, dataset, repo_name):
         """Push the final dataset to Hugging Face Hub."""
         try:
+            repo_id = f"{self.api.whoami()['name']}/{repo_name}"
             dataset.push_to_hub(repo_id)
             self._tag_dateset(repo_id)
         except Exception as e:

--- a/vqasynth/depth.py
+++ b/vqasynth/depth.py
@@ -1,8 +1,15 @@
 import cv2
+import tempfile
 import numpy as np
 from PIL import Image
 
 import depth_pro
+
+def create_temp_image(pillow_image):
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as temp_file:
+        pillow_image.save(temp_file, format='PNG')
+        temp_file_name = temp_file.name
+    return temp_file_name
 
 class DepthEstimator:
     def __init__(self):
@@ -10,18 +17,19 @@ class DepthEstimator:
         self.model, self.transform = depth_pro.create_model_and_transforms()
         self.model.eval()
 
-    def run(self, image_path):
+    def run(self, image):
         """
         Returns a depth map and formatted focal length from an image
 
         Args:
-            image_path: path to image
+            image: A PIL.Image image
 
         Returns:
             tuple: depth in meters, focal length in pixels
         """
 
         try:
+            image_path = create_temp_image(image)
             image, _, f_px = depth_pro.load_rgb(image_path)
             image_tensor = self.transform(image)
             prediction = self.model.infer(image_tensor, f_px=f_px)

--- a/vqasynth/embeddings.py
+++ b/vqasynth/embeddings.py
@@ -18,7 +18,7 @@ class EmbeddingGenerator(MultiModalEmbeddingModel):
             image (PIL.Image.Image): The input image for which embeddings are generated.
 
         Returns:
-            torch.Tensor: Normalized CLIP embeddings for the image.
+            np.ndarray: Normalized CLIP embeddings for the image.
         """
         image_input = self.preprocess(image).unsqueeze(0).to(self.device)
         with torch.no_grad():
@@ -43,7 +43,7 @@ class TagFilter(MultiModalEmbeddingModel):
             text_features = self.model.encode_text(text_inputs)
         text_features /= text_features.norm(dim=-1, keepdim=True)
 
-        image_embeddings_tensor = torch.from_numpy(image_embeddings).to(self.device)
+        image_embeddings_tensor = torch.from_numpy(np.array(image_embeddings)).to(self.device)
         similarity = (100.0 * image_embeddings_tensor @ text_features.T).softmax(dim=-1)
 
         best_index = similarity.argmax().item()

--- a/vqasynth/prompts.py
+++ b/vqasynth/prompts.py
@@ -622,10 +622,8 @@ class PromptGenerator():
             results.extend(pair_results)
         return results
 
-    def run(self, image_filename, captions, pointclouds, is_canonicalized):
-        image_file = image_filename
+    def run(self, captions, pointclouds, is_canonicalized):
         pointclouds = self.spatial_scene_constructor.restore_pointclouds(pointclouds)
-
         try:
             objects = list(zip(captions, pointclouds))
             all_pairs = [(i, j) for i in range(len(objects)) for j in range(len(objects)) if i != j]

--- a/vqasynth/scene_fusion.py
+++ b/vqasynth/scene_fusion.py
@@ -192,7 +192,10 @@ class SpatialSceneConstructor:
         )
 
         for i, mask in enumerate(masks):
-            mask_binary = mask > 0
+            if isinstance(mask, list):
+                mask = np.array(mask)
+
+            mask_binary = mask.astype(bool)
 
             masked_rgb = self.apply_mask_to_image(original_image_cv, mask_binary)
             masked_depth = self.apply_mask_to_image(depth_image_cv, mask_binary)


### PR DESCRIPTION
Instead of processing a local directory of images, we want to process from huggingface datasets which contain `PIL.Image` images that we can process. This makes it easier to use open source datasets that don't have to be wrangled locally.

This new pipeline design will also push new dataset to hf hub

Test by running:
`bash run.sh`

Test results from config.yaml setup: https://huggingface.co/datasets/salma-remyx/vqasynth_sample_processed?row=0