### PR TITLE
Fix multi-gpu OOM in localize step

### DIFF
--- a/docker/location_refinement_stage/Dockerfile
+++ b/docker/location_refinement_stage/Dockerfile
@@ -1,7 +1,7 @@
 FROM vqasynth:base
 WORKDIR /app
 
-ENV PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+ENV PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:128
 
 COPY docker/location_refinement_stage/process_location_refinement.py /app
 COPY docker/location_refinement_stage/entrypoint.sh /app

--- a/vqasynth/utils.py
+++ b/vqasynth/utils.py
@@ -6,6 +6,14 @@ import numpy as np
 import matplotlib.cm
 from PIL import Image
 
+def pick_dtype():
+    if not torch.cuda.is_available():
+        return torch.float32          # CPU path
+    major_cc, _ = torch.cuda.get_device_capability()
+    if major_cc >= 8:                 # Ampere (A10, A100, RTX30) or newer
+        return torch.bfloat16
+    return torch.float16              # older GPUs fall back to FP16
+
 def filter_null(example):
     """
     Filter out rows with None values in any of the columns.


### PR DESCRIPTION
# Fix multi-gpu OOM in Location Refinement stage

## Background
In the `location_refinement` stage of the [pipelines/spatialvqa.yaml](https://github.com/remyxai/VQASynth/blob/main/pipelines/spatialvqa.yaml) pipeline, we support two caption-localizer backends (Molmo and Florence) and a SAM2-based segmenter. When running on multiple GPUs, users encountered two main issues:
1. **Molmo multi-GPU inference failure**: Attempting to shard Molmo-7B across GPUs caused a device mismatch during vocabulary concatenation (`transformer.wte` vs `new_embedding` on different devices), leading to runtime errors (e.g., `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0`). 
2. **Florence multi-GPU inference**: The Florence model did not natively support `device_map="auto"`, which raised a `ValueError: Florence2ForConditionalGeneration does not support device_map='auto'` when used directly. We needed a different approach to distribute Florence across multiple GPUs without modifying its internal `_no_split_modules` attribute.

## Changes
This PR proposes the following changes to `vqasynth/localize.py`:
1. **Pin Molmo inference to GPU 0 only**:
   - Use `device_map={"": 0}` when loading Molmo-7B (4-bit quantized) so that all parameters stay on a single device (cuda:0). 
   - Remove any `Accelerate` hooks or multi-GPU logic for Molmo, no available kernel for this specific model.
   - Guarantee Molmo runs successfully without encountering the vocabulary concatenation error.

2. **Use `accelerate.Accelerator` for Florence multi-GPU inference**:
   - Introduce an `Accelerator` instance in `FlorenceCaptionLocalizer.post_init()`.
   - Load the Florence model weights into host memory (RAM) first, then call `accelerator.prepare(model)` to automatically shard and/or replicate the model across all available GPUs or fallback to CPU if no GPU is present.
   - Cast image inputs (`pixel_values`) to the same dtype as the model’s weights (BF16/FP16) before passing to `model.generate()` to avoid `RuntimeError: Input type (float) and bias type (c10::Half) should be the same`.

## Testing
- Verified that `process_location_refinement.py` successfully maps an example Hugging Face dataset with image columns, producing masks, bounding boxes, and captions on a 4-GPU A10 setup without OOMs.
- Confirmed that Molmo inference completes on a single GPU, and that removing `device_map="auto"` avoids the runtime mismatch.
- Confirmed that Florence inference now uses multiple GPUs and produces a well formatted dataset.
- Verified that dataset examples with no detected masks are dropped without raising Arrow casting errors.

## TODO
- Investigate whether Molmo-7B can be further optimized for multi-GPU inference by “no_split_module_classes” hacks, but the current recommended pattern is to pin it to one device.
- Consider exposing a configuration flag (e.g., `use_accelerate_for_florence`) to enable or disable sharding at runtime

