### PR TITLE
[Remyx Recommendation] Can These Views Be One Scene? Evaluating Multiview 3D Consistency when 3D Foundation Models Hallucinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,36 @@ This project was inspired by or utilizes concepts discussed in the following res
   year={2024}
 }
 ```
+
+## Can These Views Be One Scene? Integration (experimental) 🧪
+
+VQASynth's scene reconstruction stage uses VGGT to lift images into a 3D
+scene. The paper *Can These Views Be One Scene? Evaluating Multiview 3D
+Consistency when 3D Foundation Models Hallucinate*
+([arXiv:2605.18754](https://arxiv.org/abs/2605.18754v1)) shows that VGGT,
+MASt3R, DUSt3R, and Fast3R can hallucinate dense geometry and cross-view
+support on unrelated scenes, repeated images, and random noise, while
+still reporting high consistency scores. It proposes COLMAP-based,
+failure-aware consistency signals (matches, registration, dense support,
+reconstruction failure) that correlate up to 4× better with human
+judgments than MEt3R.
+
+`vqasynth/multiview_consistency_integration.py` ships a scaffold of those
+signals so they can gate downstream QA generation against hallucinated
+scenes:
+
+- `MultiviewConsistencyConfig` — paper hyperparameters as defaults
+  (inlier thresholds, registration fraction, dense-support floor,
+  aggregation weights, and the `alpha`/`gamma` parameters of the
+  parametric family that recovers MEt3R as a special case).
+- Four concrete failure-aware signals (`match_ratio_score`,
+  `registration_score`, `dense_support_score`,
+  `reconstruction_failure_score`) and their weighted aggregator.
+- `parametric_consistency_score` — closed-form
+  `alpha * backbone + (1 - alpha) * residual ** gamma`.
+- `MultiviewConsistencyEvaluator.evaluate_from_counts(...)` — combines
+  the signals into a `ConsistencyReport` with a hallucination flag.
+  The end-to-end `evaluate(...)` path that runs COLMAP / a learned
+  matcher is stubbed pending a backend choice.
+
+Contributed via [Remyx Recommendation](https://engine.remyx.ai).

--- a/tests/test_multiview_consistency_integration.py
+++ b/tests/test_multiview_consistency_integration.py
@@ -1,0 +1,353 @@
+"""
+Tests for vqasynth.multiview_consistency_integration.
+
+Covers the failure-aware consistency signals, the parametric-family
+combinator, the hallucination flag, the config validation, and a smoke
+test of the evaluator scaffold.
+"""
+
+import pytest
+
+from vqasynth.multiview_consistency_integration import (
+    ConsistencyReport,
+    MultiviewConsistencyConfig,
+    MultiviewConsistencyEvaluator,
+    aggregate_failure_aware_score,
+    dense_support_score,
+    detect_hallucination,
+    match_ratio_score,
+    parametric_consistency_score,
+    reconstruction_failure_score,
+    registration_score,
+)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def test_config_defaults_are_consistent():
+    cfg = MultiviewConsistencyConfig()
+    total = (
+        cfg.weight_matches + cfg.weight_registration
+        + cfg.weight_dense + cfg.weight_recon
+    )
+    assert total == pytest.approx(1.0)
+    assert 0.0 <= cfg.alpha <= 1.0
+    assert cfg.gamma > 0
+    assert 0.0 <= cfg.hallucination_threshold <= 1.0
+
+
+def test_config_rejects_negative_weights():
+    with pytest.raises(ValueError):
+        MultiviewConsistencyConfig(weight_matches=-0.1)
+
+
+def test_config_rejects_zero_total_weight():
+    with pytest.raises(ValueError):
+        MultiviewConsistencyConfig(
+            weight_matches=0.0,
+            weight_registration=0.0,
+            weight_dense=0.0,
+            weight_recon=0.0,
+        )
+
+
+def test_config_rejects_out_of_range_alpha():
+    with pytest.raises(ValueError):
+        MultiviewConsistencyConfig(alpha=1.5)
+
+
+def test_config_rejects_non_positive_gamma():
+    with pytest.raises(ValueError):
+        MultiviewConsistencyConfig(gamma=0.0)
+
+
+# ---------------------------------------------------------------------------
+# match_ratio_score
+# ---------------------------------------------------------------------------
+
+def test_match_ratio_zero_when_no_matches():
+    cfg = MultiviewConsistencyConfig()
+    assert match_ratio_score(0, 0, cfg) == 0.0
+
+
+def test_match_ratio_zero_when_below_inlier_min():
+    cfg = MultiviewConsistencyConfig(min_inliers=20)
+    assert match_ratio_score(10, 50, cfg) == 0.0
+
+
+def test_match_ratio_zero_when_below_ratio_min():
+    cfg = MultiviewConsistencyConfig(min_inlier_ratio=0.5)
+    assert match_ratio_score(20, 100, cfg) == 0.0
+
+
+def test_match_ratio_high_for_clean_pair():
+    cfg = MultiviewConsistencyConfig()
+    # 80% inliers, far above defaults => positive non-trivial score
+    score = match_ratio_score(80, 100, cfg)
+    assert 0.0 < score <= 1.0
+
+
+def test_match_ratio_maps_perfect_to_one():
+    cfg = MultiviewConsistencyConfig()
+    assert match_ratio_score(100, 100, cfg) == pytest.approx(1.0)
+
+
+def test_match_ratio_negative_counts_raise():
+    cfg = MultiviewConsistencyConfig()
+    with pytest.raises(ValueError):
+        match_ratio_score(-1, 10, cfg)
+
+
+# ---------------------------------------------------------------------------
+# registration_score
+# ---------------------------------------------------------------------------
+
+def test_registration_zero_when_no_views():
+    cfg = MultiviewConsistencyConfig()
+    assert registration_score(0, 0, cfg) == 0.0
+
+
+def test_registration_zero_when_below_threshold():
+    cfg = MultiviewConsistencyConfig(min_registered_fraction=0.9)
+    assert registration_score(5, 10, cfg) == 0.0
+
+
+def test_registration_returns_fraction_when_passes_threshold():
+    cfg = MultiviewConsistencyConfig(min_registered_fraction=0.5)
+    assert registration_score(9, 10, cfg) == pytest.approx(0.9)
+
+
+def test_registration_one_when_all_registered():
+    cfg = MultiviewConsistencyConfig()
+    assert registration_score(10, 10, cfg) == pytest.approx(1.0)
+
+
+def test_registration_rejects_overcount():
+    cfg = MultiviewConsistencyConfig()
+    with pytest.raises(ValueError):
+        registration_score(11, 10, cfg)
+
+
+# ---------------------------------------------------------------------------
+# dense_support_score
+# ---------------------------------------------------------------------------
+
+def test_dense_support_empty_views():
+    cfg = MultiviewConsistencyConfig()
+    assert dense_support_score([], [], cfg) == 0.0
+
+
+def test_dense_support_length_mismatch_raises():
+    cfg = MultiviewConsistencyConfig()
+    with pytest.raises(ValueError):
+        dense_support_score([10, 20], [100], cfg)
+
+
+def test_dense_support_zero_total_pixels_view_scores_zero():
+    cfg = MultiviewConsistencyConfig()
+    assert dense_support_score([0], [0], cfg) == 0.0
+
+
+def test_dense_support_passes_when_all_views_above_threshold():
+    cfg = MultiviewConsistencyConfig(min_dense_support=0.3)
+    # 50% and 60% coverage across two views
+    score = dense_support_score([50, 60], [100, 100], cfg)
+    assert score == pytest.approx(0.55)
+
+
+def test_dense_support_zeros_views_below_threshold():
+    cfg = MultiviewConsistencyConfig(min_dense_support=0.4)
+    # First view above (50%), second below (20%) -> mean = (0.5 + 0) / 2
+    score = dense_support_score([50, 20], [100, 100], cfg)
+    assert score == pytest.approx(0.25)
+
+
+def test_dense_support_rejects_negative():
+    cfg = MultiviewConsistencyConfig()
+    with pytest.raises(ValueError):
+        dense_support_score([-1], [10], cfg)
+
+
+def test_dense_support_rejects_overcoverage():
+    cfg = MultiviewConsistencyConfig()
+    with pytest.raises(ValueError):
+        dense_support_score([20], [10], cfg)
+
+
+# ---------------------------------------------------------------------------
+# reconstruction_failure_score
+# ---------------------------------------------------------------------------
+
+def test_reconstruction_failure_truthy():
+    assert reconstruction_failure_score(True) == 1.0
+    assert reconstruction_failure_score(False) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# aggregate_failure_aware_score
+# ---------------------------------------------------------------------------
+
+def test_aggregate_failure_aware_with_default_weights():
+    cfg = MultiviewConsistencyConfig()
+    score = aggregate_failure_aware_score(1.0, 1.0, 1.0, 1.0, cfg)
+    assert score == pytest.approx(1.0)
+    score = aggregate_failure_aware_score(0.0, 0.0, 0.0, 0.0, cfg)
+    assert score == pytest.approx(0.0)
+
+
+def test_aggregate_failure_aware_weighted_correctly():
+    cfg = MultiviewConsistencyConfig(
+        weight_matches=1.0,
+        weight_registration=0.0,
+        weight_dense=0.0,
+        weight_recon=0.0,
+    )
+    # Only matches matter
+    assert aggregate_failure_aware_score(0.5, 1.0, 1.0, 1.0, cfg) == pytest.approx(0.5)
+
+
+def test_aggregate_failure_aware_rejects_out_of_range():
+    cfg = MultiviewConsistencyConfig()
+    with pytest.raises(ValueError):
+        aggregate_failure_aware_score(1.1, 0.5, 0.5, 0.5, cfg)
+
+
+# ---------------------------------------------------------------------------
+# parametric_consistency_score
+# ---------------------------------------------------------------------------
+
+def test_parametric_recovers_backbone_when_alpha_one():
+    cfg = MultiviewConsistencyConfig(alpha=1.0, gamma=1.0)
+    assert parametric_consistency_score(0.7, 0.2, cfg) == pytest.approx(0.7)
+
+
+def test_parametric_uses_residual_when_alpha_zero():
+    cfg = MultiviewConsistencyConfig(alpha=0.0, gamma=1.0)
+    assert parametric_consistency_score(0.7, 0.2, cfg) == pytest.approx(0.2)
+
+
+def test_parametric_gamma_dampens_residual():
+    cfg = MultiviewConsistencyConfig(alpha=0.0, gamma=2.0)
+    # With gamma=2, 0.5 ** 2 = 0.25
+    assert parametric_consistency_score(0.0, 0.5, cfg) == pytest.approx(0.25)
+
+
+def test_parametric_score_clipped_to_unit_interval():
+    cfg = MultiviewConsistencyConfig(alpha=0.5, gamma=1.0)
+    score = parametric_consistency_score(1.0, 1.0, cfg)
+    assert 0.0 <= score <= 1.0
+
+
+def test_parametric_rejects_out_of_range_inputs():
+    cfg = MultiviewConsistencyConfig()
+    with pytest.raises(ValueError):
+        parametric_consistency_score(1.1, 0.5, cfg)
+    with pytest.raises(ValueError):
+        parametric_consistency_score(0.5, -0.1, cfg)
+
+
+# ---------------------------------------------------------------------------
+# detect_hallucination
+# ---------------------------------------------------------------------------
+
+def test_detect_hallucination_below_threshold():
+    cfg = MultiviewConsistencyConfig(hallucination_threshold=0.5)
+    assert detect_hallucination(0.2, cfg) is True
+    assert detect_hallucination(0.5, cfg) is False
+    assert detect_hallucination(0.9, cfg) is False
+
+
+def test_detect_hallucination_rejects_out_of_range():
+    cfg = MultiviewConsistencyConfig()
+    with pytest.raises(ValueError):
+        detect_hallucination(1.5, cfg)
+
+
+# ---------------------------------------------------------------------------
+# MultiviewConsistencyEvaluator
+# ---------------------------------------------------------------------------
+
+def test_evaluator_clean_scene_passes():
+    """A 'clean' multi-view scene should produce a high score and no flag."""
+    ev = MultiviewConsistencyEvaluator()
+    report = ev.evaluate_from_counts(
+        num_inliers=400,
+        num_matches=500,
+        num_registered=8,
+        num_views=8,
+        covered_pixels=[80_000] * 8,
+        total_pixels=[100_000] * 8,
+        reconstruction_succeeded=True,
+    )
+    assert isinstance(report, ConsistencyReport)
+    assert report.combined_score > 0.5
+    assert report.hallucination_flag is False
+
+
+def test_evaluator_hallucination_scene_flagged():
+    """
+    A scene of mostly unrelated views (few inliers, registration fails,
+    reconstruction errors out) should drop the combined score below
+    threshold even if the neural backbone reported high confidence.
+    """
+    ev = MultiviewConsistencyEvaluator()
+    report = ev.evaluate_from_counts(
+        num_inliers=2,
+        num_matches=300,
+        num_registered=1,
+        num_views=8,
+        covered_pixels=[1_000] * 8,
+        total_pixels=[100_000] * 8,
+        reconstruction_succeeded=False,
+    )
+    assert report.match_score == 0.0
+    assert report.registration_score == 0.0
+    assert report.dense_score == 0.0
+    assert report.recon_score == 0.0
+    assert report.combined_score == 0.0
+    assert report.hallucination_flag is True
+
+
+def test_evaluator_attaches_parametric_when_backbone_given():
+    ev = MultiviewConsistencyEvaluator(
+        MultiviewConsistencyConfig(alpha=0.5, gamma=1.0)
+    )
+    report = ev.evaluate_from_counts(
+        num_inliers=400,
+        num_matches=500,
+        num_registered=8,
+        num_views=8,
+        covered_pixels=[80_000] * 8,
+        total_pixels=[100_000] * 8,
+        reconstruction_succeeded=True,
+        backbone_score=0.9,
+    )
+    assert report.parametric_score is not None
+    assert 0.0 <= report.parametric_score <= 1.0
+
+
+def test_evaluator_evaluate_is_not_implemented():
+    """The end-to-end path requires a COLMAP/matcher backend not wired up yet."""
+    ev = MultiviewConsistencyEvaluator()
+    with pytest.raises(NotImplementedError):
+        ev.evaluate(images=[None, None])
+
+
+def test_evaluator_diagnostics_round_trip():
+    ev = MultiviewConsistencyEvaluator()
+    report = ev.evaluate_from_counts(
+        num_inliers=50,
+        num_matches=200,
+        num_registered=6,
+        num_views=8,
+        covered_pixels=[40_000] * 8,
+        total_pixels=[100_000] * 8,
+        reconstruction_succeeded=True,
+    )
+    assert report.diagnostics["num_inliers"] == 50
+    assert report.diagnostics["num_matches"] == 200
+    assert report.diagnostics["num_registered"] == 6
+    assert report.diagnostics["num_views"] == 8
+    assert report.diagnostics["reconstruction_succeeded"] is True

--- a/vqasynth/multiview_consistency_integration.py
+++ b/vqasynth/multiview_consistency_integration.py
@@ -1,0 +1,407 @@
+"""
+Multiview 3D consistency metrics for VQASynth's VGGT reconstruction stage.
+
+Scaffold for the COLMAP-based, failure-aware consistency signals introduced in:
+
+    Can These Views Be One Scene? Evaluating Multiview 3D Consistency when
+    3D Foundation Models Hallucinate
+    (arXiv:2605.18754v1)
+
+VQASynth currently relies on VGGT (vqasynth/scene_fusion.py) to lift images
+into a 3D scene used by the rest of the pipeline. The paper shows VGGT can
+hallucinate dense geometry and cross-view support for unrelated views,
+repeated images, and random noise. The signals here let the pipeline flag
+such hallucinations before downstream QA generation.
+
+Three groups of primitives are exposed:
+
+1. Failure-aware consistency signals (matches, registration, dense support,
+   reconstruction-failure) computed from generic feature-matching outputs.
+   These are concrete and tested.
+
+2. A parametric family decomposing neural metrics into backbone / residual /
+   aggregation components. The closed-form combinator is concrete; the
+   backbone signal is taken as input rather than computed here.
+
+3. A class scaffold (MultiviewConsistencyEvaluator) that wires the signals
+   into a single score and a hallucination flag. The heavy lifting (running
+   COLMAP, extracting SIFT/SuperPoint matches, calling MEt3R) is left as
+   documented TODOs so this module doesn't pretend to do work that requires
+   external dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MultiviewConsistencyConfig:
+    """
+    Hyperparameters for the failure-aware consistency metrics.
+
+    Defaults are taken from the paper's reported settings where stated and
+    from reasonable choices otherwise. They are deliberately conservative:
+    a view-set should score high only when the geometric evidence is strong.
+    """
+
+    # --- Match-based signal --------------------------------------------------
+    # Minimum inliers (post-RANSAC) for a pair to count as "matched".
+    min_inliers: int = 15
+    # Minimum inlier/match ratio for a pair to count as geometrically valid.
+    min_inlier_ratio: float = 0.10
+
+    # --- Registration signal -------------------------------------------------
+    # Minimum fraction of input views that must be successfully registered
+    # by COLMAP for the scene to count as "registered".
+    min_registered_fraction: float = 0.80
+
+    # --- Dense support signal ------------------------------------------------
+    # Minimum fraction of pixels in each view that must be covered by the
+    # dense 3D support (i.e., a depth/point estimate consistent with the
+    # global model).
+    min_dense_support: float = 0.30
+
+    # --- Aggregation weights (failure-aware combined score) -----------------
+    # These weight the four failure-aware signals into a single [0, 1] score.
+    # The defaults give roughly equal weight, slightly biased towards the
+    # match signal since the paper finds geometric verification to be the
+    # most reliable individual signal.
+    weight_matches: float = 0.35
+    weight_registration: float = 0.25
+    weight_dense: float = 0.25
+    weight_recon: float = 0.15
+
+    # --- Parametric family (backbone / residual / aggregation) --------------
+    # The paper introduces a parametric family that recovers MEt3R as a
+    # special case and yields variants up to 3x more robust. Here the
+    # backbone and residual signals are taken as inputs; alpha controls the
+    # mix and gamma is an exponent on the residual term (aggregation).
+    alpha: float = 0.5
+    gamma: float = 1.0
+
+    # --- Hallucination threshold --------------------------------------------
+    # Combined scores below this are flagged as hallucination candidates.
+    hallucination_threshold: float = 0.4
+
+    # --- Bookkeeping ---------------------------------------------------------
+    # Optional cache directory for COLMAP intermediates. Not used until the
+    # COLMAP backend is implemented.
+    cache_dir: Optional[str] = None
+
+    def __post_init__(self):
+        weights = (
+            self.weight_matches,
+            self.weight_registration,
+            self.weight_dense,
+            self.weight_recon,
+        )
+        if any(w < 0 for w in weights):
+            raise ValueError("Aggregation weights must be non-negative.")
+        total = sum(weights)
+        if total <= 0:
+            raise ValueError("At least one aggregation weight must be positive.")
+        if not (0.0 <= self.alpha <= 1.0):
+            raise ValueError("alpha must lie in [0, 1].")
+        if self.gamma <= 0:
+            raise ValueError("gamma must be positive.")
+
+
+# ---------------------------------------------------------------------------
+# Failure-aware consistency signals
+# ---------------------------------------------------------------------------
+
+def match_ratio_score(num_inliers: int, num_matches: int, config: MultiviewConsistencyConfig) -> float:
+    """
+    Score a single pair of views by their inlier ratio after geometric
+    verification (e.g., RANSAC + fundamental matrix).
+
+    Returns a value in [0, 1]. Pairs that fall below either the absolute
+    inlier count or the inlier/match ratio thresholds score 0.
+
+    Args:
+        num_inliers: Number of inliers surviving geometric verification.
+        num_matches: Total number of putative matches before verification.
+        config: Thresholds (min_inliers, min_inlier_ratio).
+    """
+    if num_inliers < 0 or num_matches < 0:
+        raise ValueError("Counts must be non-negative.")
+    if num_matches == 0:
+        return 0.0
+    ratio = num_inliers / num_matches
+    if num_inliers < config.min_inliers or ratio < config.min_inlier_ratio:
+        return 0.0
+    # Map ratio to [0, 1] with a linear ramp above the minimum threshold.
+    span = 1.0 - config.min_inlier_ratio
+    if span <= 0:
+        return 1.0
+    return min(1.0, max(0.0, (ratio - config.min_inlier_ratio) / span))
+
+
+def registration_score(num_registered: int, num_views: int, config: MultiviewConsistencyConfig) -> float:
+    """
+    Score how completely a COLMAP-style SfM pipeline registers the input
+    views. A scene where most views drop out is a strong hallucination
+    signal for any neural reconstructor that nonetheless reports high
+    consistency.
+
+    Returns a value in [0, 1] (the fraction of registered views), or 0.0
+    when that fraction falls below ``config.min_registered_fraction``.
+    """
+    if num_registered < 0 or num_views < 0:
+        raise ValueError("Counts must be non-negative.")
+    if num_views == 0:
+        return 0.0
+    if num_registered > num_views:
+        raise ValueError("Registered count cannot exceed total views.")
+    frac = num_registered / num_views
+    if frac < config.min_registered_fraction:
+        return 0.0
+    return frac
+
+
+def dense_support_score(
+    covered_pixels: Sequence[int],
+    total_pixels: Sequence[int],
+    config: MultiviewConsistencyConfig,
+) -> float:
+    """
+    Score the fraction of each view's pixels that have a dense 3D estimate
+    consistent with the registered global model. Aggregated as the mean
+    across views; views below the per-view minimum score 0 for that view.
+
+    Args:
+        covered_pixels: Per-view count of pixels with valid dense support.
+        total_pixels:   Per-view total pixel count (must match length).
+
+    Returns a value in [0, 1].
+    """
+    if len(covered_pixels) != len(total_pixels):
+        raise ValueError("covered_pixels and total_pixels must have the same length.")
+    if not covered_pixels:
+        return 0.0
+    per_view = []
+    for covered, total in zip(covered_pixels, total_pixels):
+        if covered < 0 or total < 0:
+            raise ValueError("Counts must be non-negative.")
+        if total == 0:
+            per_view.append(0.0)
+            continue
+        if covered > total:
+            raise ValueError("Covered pixels cannot exceed total pixels.")
+        frac = covered / total
+        per_view.append(frac if frac >= config.min_dense_support else 0.0)
+    return sum(per_view) / len(per_view)
+
+
+def reconstruction_failure_score(reconstruction_succeeded: bool) -> float:
+    """
+    Binary signal: 1.0 if the classical SfM/MVS step finished without
+    a hard failure, 0.0 otherwise. The paper treats reconstruction
+    failure itself as one of the strongest cues that a view-set is
+    inconsistent regardless of what a neural backbone reports.
+    """
+    return 1.0 if reconstruction_succeeded else 0.0
+
+
+def aggregate_failure_aware_score(
+    match: float,
+    registration: float,
+    dense: float,
+    recon: float,
+    config: MultiviewConsistencyConfig,
+) -> float:
+    """
+    Weighted average of the four failure-aware signals using weights from
+    ``config``. Each component is clipped into [0, 1] first.
+    """
+    parts = (match, registration, dense, recon)
+    if any((p < 0.0 or p > 1.0) for p in parts):
+        raise ValueError("Component scores must lie in [0, 1].")
+    weights = (
+        config.weight_matches,
+        config.weight_registration,
+        config.weight_dense,
+        config.weight_recon,
+    )
+    total_weight = sum(weights)
+    weighted = sum(p * w for p, w in zip(parts, weights))
+    return weighted / total_weight
+
+
+# ---------------------------------------------------------------------------
+# Parametric family (recovers MEt3R as a special case)
+# ---------------------------------------------------------------------------
+
+def parametric_consistency_score(
+    backbone: float,
+    residual: float,
+    config: MultiviewConsistencyConfig,
+) -> float:
+    """
+    Closed-form parametric family from the paper, decomposing neural
+    consistency metrics into backbone, residual, and aggregation
+    components::
+
+        score = alpha * backbone + (1 - alpha) * residual ** gamma
+
+    With ``alpha = 1, gamma = 1`` this reduces to a pure backbone signal
+    (recovering MEt3R). Lowering ``alpha`` and raising ``gamma`` makes
+    the metric punish residual hallucination more aggressively; the paper
+    reports variants up to 3x more robust by tuning this family.
+
+    Both inputs and the result lie in [0, 1].
+    """
+    if not (0.0 <= backbone <= 1.0) or not (0.0 <= residual <= 1.0):
+        raise ValueError("backbone and residual must lie in [0, 1].")
+    score = config.alpha * backbone + (1.0 - config.alpha) * (residual ** config.gamma)
+    return max(0.0, min(1.0, score))
+
+
+def detect_hallucination(combined_score: float, config: MultiviewConsistencyConfig) -> bool:
+    """True if ``combined_score`` falls below the hallucination threshold."""
+    if not (0.0 <= combined_score <= 1.0):
+        raise ValueError("combined_score must lie in [0, 1].")
+    return combined_score < config.hallucination_threshold
+
+
+# ---------------------------------------------------------------------------
+# Evaluator class scaffold
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ConsistencyReport:
+    """Per-scene output of MultiviewConsistencyEvaluator.evaluate."""
+
+    match_score: float
+    registration_score: float
+    dense_score: float
+    recon_score: float
+    combined_score: float
+    hallucination_flag: bool
+    parametric_score: Optional[float] = None
+    diagnostics: dict = field(default_factory=dict)
+
+
+class MultiviewConsistencyEvaluator:
+    """
+    Drives the consistency signals against the kind of multi-view input
+    VQASynth's scene_fusion stage produces (a set of images plus a VGGT-
+    derived point cloud / depth map).
+
+    Heavy lifting is intentionally stubbed:
+
+    - ``_extract_pairwise_matches``: would shell out to COLMAP or run a
+      learned matcher (SIFT, SuperPoint+LightGlue, etc.).
+    - ``_run_sfm``: would run COLMAP's incremental SfM and return the
+      number of registered views and per-view dense support.
+    - ``_neural_backbone_score``: would call MEt3R or another learned
+      metric on the same view set.
+
+    The class exposes the pure-Python wiring so callers can already pass
+    in pre-computed counts (e.g., from an external COLMAP run) and get a
+    combined score + hallucination flag back.
+    """
+
+    def __init__(self, config: Optional[MultiviewConsistencyConfig] = None):
+        self.config = config or MultiviewConsistencyConfig()
+
+    # -- Public API ----------------------------------------------------------
+
+    def evaluate_from_counts(
+        self,
+        num_inliers: int,
+        num_matches: int,
+        num_registered: int,
+        num_views: int,
+        covered_pixels: Sequence[int],
+        total_pixels: Sequence[int],
+        reconstruction_succeeded: bool,
+        backbone_score: Optional[float] = None,
+    ) -> ConsistencyReport:
+        """
+        Compute a full consistency report from pre-computed signal counts.
+
+        This is the path that's fully implemented today. Callers that have
+        already run COLMAP (or any equivalent) externally can feed counts
+        in directly and get the failure-aware aggregation + hallucination
+        flag for free.
+
+        ``backbone_score`` is optional. When provided, the parametric
+        family is also evaluated and attached to the report.
+        """
+        cfg = self.config
+        m = match_ratio_score(num_inliers, num_matches, cfg)
+        r = registration_score(num_registered, num_views, cfg)
+        d = dense_support_score(covered_pixels, total_pixels, cfg)
+        f = reconstruction_failure_score(reconstruction_succeeded)
+        combined = aggregate_failure_aware_score(m, r, d, f, cfg)
+        parametric = None
+        if backbone_score is not None:
+            parametric = parametric_consistency_score(backbone_score, combined, cfg)
+        return ConsistencyReport(
+            match_score=m,
+            registration_score=r,
+            dense_score=d,
+            recon_score=f,
+            combined_score=combined,
+            hallucination_flag=detect_hallucination(combined, cfg),
+            parametric_score=parametric,
+            diagnostics={
+                "num_inliers": num_inliers,
+                "num_matches": num_matches,
+                "num_registered": num_registered,
+                "num_views": num_views,
+                "reconstruction_succeeded": reconstruction_succeeded,
+            },
+        )
+
+    def evaluate(self, images, point_cloud=None) -> ConsistencyReport:
+        """
+        End-to-end evaluation entry point. Not implemented yet because it
+        requires either a COLMAP binary on PATH or a learned matcher with
+        its own checkpoints (SuperPoint+LightGlue, etc.). The intended
+        wiring is:
+
+            matches = self._extract_pairwise_matches(images)
+            sfm = self._run_sfm(images, matches)
+            backbone = self._neural_backbone_score(images)
+            return self.evaluate_from_counts(
+                num_inliers=matches.num_inliers,
+                num_matches=matches.num_putative,
+                num_registered=sfm.num_registered,
+                num_views=len(images),
+                covered_pixels=sfm.dense_covered_per_view,
+                total_pixels=sfm.dense_total_per_view,
+                reconstruction_succeeded=sfm.succeeded,
+                backbone_score=backbone,
+            )
+
+        See ``evaluate_from_counts`` for the path that works today.
+        """
+        # TODO(remyx-recommendation): wire COLMAP / learned matcher backend.
+        raise NotImplementedError(
+            "MultiviewConsistencyEvaluator.evaluate requires a COLMAP or "
+            "learned-matcher backend that is not yet integrated. Use "
+            "evaluate_from_counts(...) with externally computed counts in "
+            "the meantime."
+        )
+
+    # -- Stubs for the heavy components -------------------------------------
+
+    def _extract_pairwise_matches(self, images):
+        # TODO(remyx-recommendation): SIFT/SuperPoint + RANSAC.
+        raise NotImplementedError
+
+    def _run_sfm(self, images, matches):
+        # TODO(remyx-recommendation): COLMAP incremental SfM + dense MVS.
+        raise NotImplementedError
+
+    def _neural_backbone_score(self, images):
+        # TODO(remyx-recommendation): MEt3R or VGGT-derived backbone score.
+        raise NotImplementedError


### PR DESCRIPTION
> **Drafted by an autonomous discovery loop** — Remyx ranks recent arXiv papers against this team's research interest and shipping history; Claude Code implements the top pick.
>
> **Recommended paper**: [Can These Views Be One Scene? Evaluating Multiview 3D Consistency when 3D Foundation Models Hallucinate](https://arxiv.org/abs/2605.18754v1)
> **Confidence**: 🟢 high (Remyx relevance 0.87)
> **Research interest**: VQASynth
> **Implementation by**: Claude Code as autonomous agent

---

## Why this paper for this team

VQASynth generates synthetic data from 3D scene reconstructions, making 'Evaluation of Synthetic Data' and the 'Add multi-benchmark evaluation stage' critical. This paper directly addresses the reliability of multiview 3D consistency, revealing that 3D foundation models can hallucinate. It introduces controlled benchmarks and COLMAP-based metrics to assess 3D consistency more reliably. This research significantly improves VQASynth's evaluation strategy by providing robust, human-correlated metrics to verify the geometric integrity and cross-view consistency of the underlying 3D scenes from which QA pairs are generated. This is crucial for ensuring the high quality of synthetic data and preventing training VLMs on inconsistent 3D information.

## Suggested experiment

For a small batch of VQASynth's input images, process them through the depth and fusion stages to obtain a 3D scene. Apply the COLMAP-based consistency metrics proposed in this paper to assess the geometric integrity and multi-view consistency of the reconstructed scene. Identify potential instances of 'hallucination' or inconsistency to inform improvements in VQASynth's 3D reconstruction pipeline.

---

### Test results

✅ All tests passed.


---

_Opened by the [Remyx Recommendation](https://engine.remyx.ai) orchestrator._
