### PR TITLE
Restore Remyx Recommendation weekly cadence after validation

### DIFF
--- a/.github/workflows/remyx-recommendation.yml
+++ b/.github/workflows/remyx-recommendation.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: remyxai/remyx-recommendation-action@v1
         with:
           interest-id: 8c1de057-99fa-405f-a7af-7842492d2873
-          # Bypass per-day rate limit while we validate the new direct-
-          # install action. Bump back to 7 (or remove) once a few clean
-          # runs are in.
-          rate-limit-days: '0'
+          # Validation complete (action v1.0.6: candidate selection over a
+          # weekly pool + role-based guardrails). Rate limit restored to the
+          # action default (7 days) for a weekly cadence — drop the override.


### PR DESCRIPTION
The Remyx Recommendation action's candidate-selection pass and role-based guardrails (action **v1.0.6**) are validated end-to-end against this repo — see draft PR #73 (SpaceDG robustness-evaluation wired into the eval stage).

This drops the temporary `rate-limit-days: '0'` override that let us dispatch repeatedly during validation. With it gone, the workflow uses the action's default (**7 days**), restoring the intended weekly cadence on the existing cron.

`@v1` already resolves to v1.0.6 (the major tag was moved at release), so no ref change is needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)