### PR TITLE
Set rate-limit-days: '0' on VQASynth for daily-candidate cadence

### DIFF
--- a/.github/workflows/outrider.yml
+++ b/.github/workflows/outrider.yml
@@ -31,6 +31,9 @@ jobs:
       - uses: remyxai/outrider@v1
         with:
           interest-id: 8c1de057-99fa-405f-a7af-7842492d2873
-          # Validation complete (action v1.0.6: candidate selection over a
-          # weekly pool + role-based guardrails). Rate limit restored to the
-          # action default (7 days) for a weekly cadence — drop the override.
+          # Daily-candidate evaluation: disable the per-repo rate-limit
+          # window so the cron actually fires every day. With the default
+          # 7-day floor, 6/7 daily runs would short-circuit at
+          # skipped_rate_limit. Per-paper dedup (open PR or open Issue for
+          # the same arxiv_id) still prevents duplicate work day-over-day.
+          rate-limit-days: '0'


### PR DESCRIPTION
## Summary

The cron already fires daily (`0 6 * * *`), but with the default 7-day `rate-limit-days`, only 1 of every 7 runs actually does work — the other 6 short-circuit at `skipped_rate_limit` before paper selection.

Setting `rate-limit-days: '0'` relies on **per-paper dedup** instead: each daily run queries the candidate pool, drops any arxiv_id that already has an open PR or open Issue on the repo, and picks the most implementable from what remains. New papers landing day-over-day get scouted as they appear.

## Context

This matches the pre-validation setup (`mhpd-dpo-training/agent` commit `f595097`: "keep rate_limit_days=0 on VQASynth for daily-candidate eval"). The override was dropped during weekly-cadence validation; this restores it.

## What's unchanged

- Cron schedule: `0 6 * * *` (already daily)
- Per-paper dedup: still active — no duplicate PRs/Issues for the same arxiv_id
- Confidence gate: still `moderate` (default)
- All other action behavior

## Test plan

- [ ] Merge → trigger `workflow_dispatch` immediately
- [ ] Confirm the action no longer hits `skipped_rate_limit` (PR #73 is from 2026-05-29 and now ignored)
- [ ] Daily cron continues firing at 06:00 UTC starting tomorrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)