### PR TITLE
Shift Outrider daily cron 06:00 UTC → 14:00 UTC

### DIFF
--- a/.github/workflows/outrider.yml
+++ b/.github/workflows/outrider.yml
@@ -13,7 +13,7 @@ name: Outrider
 
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 14 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Shifts the daily Outrider cron from \`0 6 * * *\` to \`0 14 * * *\`.

06:00 UTC fires at 11pm Pacific the previous day — PRs/Issues arrive mid-evening when no one's looking. 14:00 UTC maps to 7am Pacific / 10am Eastern / 3pm London / 9pm Tokyo, which gets the artifact in front of the team during waking hours across the major time zones.

Tracks the same shift in the outrider README example ([remyxai/outrider#17](https://github.com/remyxai/outrider/pull/17)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)