### PR TITLE
chore: remove unused spacy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ onnxruntime-gpu==1.18.1
 pandas==2.2.3
 html5lib==1.1
 datasets==3.1.0
-spacy==3.7.5
 bitsandbytes
 peft
 tensorflow

--- a/vqasynth/localize.py
+++ b/vqasynth/localize.py
@@ -2,7 +2,6 @@ import random
 import re
 import numpy as np
 import torch
-import spacy
 from PIL import Image
 
 from transformers import (
@@ -57,7 +56,6 @@ def extract_captions(raw_text):
 class BaseCaptionLocalizer:
     def __init__(self, device=None):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
-        self.nlp = spacy.load("en_core_web_sm")
         self.torch_dtype = torch.float16
         self.model = None
         self.processor = None


### PR DESCRIPTION
## Summary

`vqasynth/localize.py` imports spacy and loads `en_core_web_sm` in `BaseCaptionLocalizer.__init__`, but `self.nlp` is never referenced anywhere else in the tree. The install pulls in the full spaCy stack plus a model download for an unused attribute — real friction for new contributors and CI, no functional gain.

## Changes

- `vqasynth/localize.py` — drop `import spacy` and `self.nlp = spacy.load("en_core_web_sm")`
- `requirements.txt` — drop `spacy==3.7.5`

## Verification

- `grep -rn "spacy\|en_core_web\|self.nlp"` on both `vqasynth/` and `tests/` — no remaining references
- `from vqasynth.localize import Localizer` succeeds with `sys.modules['spacy'] = None` (proves spacy is no longer needed to import the module)
- No test references or downstream call sites to update

## Test plan

- [ ] CI passes (import resolution unchanged besides the deleted line)
- [ ] Any pipeline that instantiates `Localizer` still constructs successfully without spacy in the environment