### PR TITLE
security: bump litellm 1.83.13 → 1.84.0 (critical auth bypass fix)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ onnx==1.13.1
 onnxruntime==1.15.1
 scipy==1.12.0
 openai==2.24.0
-litellm==1.83.13
+litellm==1.84.0
 onnxruntime-gpu==1.18.1
 pandas==2.2.3
 datasets==3.1.0


### PR DESCRIPTION
## Summary

Closes two open Dependabot alerts on this repo:

- **#49 (critical)** — LiteLLM: Authentication Bypass via Host Header Injection. Fixed in `1.84.0`.
- **#50 (high)** — authenticated `internal_user` can create API keys with access to routes their role does not permit. Fixed in `1.83.14`.

Bumping to `1.84.0` closes both in one line.

## Changes

`requirements.txt` — `litellm==1.83.13` → `litellm==1.84.0`.

## Context

Follow-up to #63 (previous litellm 1.79 → 1.83.13 bump); the current critical was published after that PR landed.

## Test plan

- [ ] CI passes
- [ ] Import paths in `vqasynth/` that touch litellm still resolve (litellm is used at 2 sites, both stable across this bump)