### PR TITLE
security: bump transformers 4.44.2 → 4.48.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ open3d==0.18.0
 opencv-python==4.8.1.78
 tqdm==4.66.3
 matplotlib==3.6.2
-transformers==4.44.2
+transformers==4.48.0
 huggingface-hub==0.25.1
 onnx==1.13.1
 onnxruntime==1.15.1


### PR DESCRIPTION
## Summary

Closes 4 open Dependabot alerts:
- **#18 (high)** — Deserialization of Untrusted Data (fixed in 4.48.0)
- **#19 (high)** — Deserialization of Untrusted Data (fixed in 4.48.0)
- **#20 (high)** — Deserialization of Untrusted Data (fixed in 4.48.0)
- **#26 (medium)** — (fixed in 4.48.0)

## Changes

`requirements.txt` — `transformers==4.44.2` → `transformers==4.48.0`.

## Smoke verification

Tested against the vqasynth API surface at 4.48.0 (import + mock-instantiation, no real weight downloads):
- Import walk of 8 vqasynth modules — passes
- `FlorenceCaptionLocalizer` + `VLMInference` construct with mocked `.from_pretrained` — passes
- `AutoModelForCausalLM.from_pretrained` positional-call path (as used in `localize.py:99, 190`) — unchanged
- `BitsAndBytesConfig(load_in_4bit=True)` — constructs correctly (requires `bitsandbytes` installed, already in `requirements.txt`)
- `GenerationConfig`, `AutoModelForVision2Seq`, `AutoProcessor` signatures — stable

## Remaining alerts (future PRs)

Not closed by 4.48.0 — larger jumps needed:
- 4.50.0 fixes: #29, #30 (medium)
- 4.51.0 fixes: #31, #32 (medium)
- 4.52.1 fixes: #33 (low), #34 (medium)
- 4.53.0 fixes: #35, #36, #37, #38 (medium)
- 5.0.0rc3+: #48 (medium)
- 5.3.0+: #51 (high)
- 5.5.0+: #53 (high)

Recommend a follow-up PR bumping to the latest 4.x (~4.53.0) that closes the mediums without a major-version jump, and reserve the 5.x bump for a separate PR with real-model behavior testing.

## Test plan

- [ ] CI passes
- [ ] Manual: `Localizer(captioner_type="florence").run(image)` on a test image still produces masks + captions
- [ ] Manual: `VLMInference.predict(image, question)` still returns text