### PR TITLE
security: bump onnx 1.13.1 → 1.21.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tqdm==4.66.3
 matplotlib==3.6.2
 transformers==4.48.0
 huggingface-hub==0.25.1
-onnx==1.13.1
+onnx==1.21.0
 onnxruntime==1.15.1
 scipy==1.12.0
 openai==2.24.0


### PR DESCRIPTION
## Summary

Closes 10 of 11 open Dependabot alerts on `onnx`:

| # | Severity | Vulnerable range | Fix |
|---:|---|---|---|
| #1 | high | ≤ 1.15.0 | 1.16.0 |
| #2 | medium | ≤ 1.15.0 | 1.16.0 |
| #17 | high | < 1.16.2 | 1.16.2 |
| #27 | high | < 1.17.0 | 1.17.0 |
| #39 | high | ≤ 1.20.1 | 1.21.0rc1 |
| #40 | high | ≤ 1.20.0 | 1.21.0 |
| #41 | high | ≤ 1.20.1 | 1.21.0 |
| #42 | medium | ≤ 1.20.1 | 1.21.0 |
| #43 | medium | < 1.21.0 | 1.21.0 |
| #44 | high | ≤ 1.20.1 | 1.21.0 |

## Changes

`requirements.txt` — `onnx==1.13.1` → `onnx==1.21.0`.

## Why this is low-risk despite the major-version jump

The `onnx` Python package is **not directly imported anywhere** in `vqasynth/`, `docker/`, `pipelines/`, or `tests/`. Only `onnxruntime` is used (`depth.py:8` — `import onnxruntime as ort`). `onnx` is a transitive dep of `onnxruntime`; this bump only updates version metadata, and no API surface exercised by vqasynth changes across the 1.13 → 1.21 jump.

Smoke-tested locally: `onnxruntime.InferenceSession` still present and callable with `onnx==1.21.0` installed.

## Remaining alert

- **#52 (medium)** — needs `onnx==1.22.0`. Follow-up PR if desired; low urgency (medium severity, transitive-only surface).

## Test plan

- [ ] CI passes
- [ ] Manual: `DepthEstimator.run(image)` still produces a depth map on both PyTorch and ONNX backends