### PR TITLE
docs: streamline README samples, label SpaceThinker examples, add 2 Colab notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,7 @@ VQASynth 🎹 provides an open-source reproduction of [SpatialVLM](https://spati
 * [OpenSpaces_MC_R1](https://huggingface.co/datasets/remyxai/OpenSpaces_MC_R1)
 * [OpenSpaces](https://huggingface.co/datasets/remyxai/OpenSpaces)
 * [vqasynth_spacellava](https://huggingface.co/datasets/remyxai/vqasynth_spacellava)
-  
-Here are some samples from the VQASynth pipeline:
 
-| <img src="https://github.com/remyxai/VQASynth/blob/main/assets/warehouse_sample_1.jpeg?raw=true"  alt="sample_1" style="max-height: 350px;" > | <img src="https://github.com/remyxai/VQASynth/blob/main/assets/warehouse_sample_2.jpeg?raw=true"  alt="sample_2" style="max-height: 350px;"> | <img src="https://github.com/remyxai/VQASynth/blob/main/assets/warehouse_sample_3.jpeg?raw=true" alt="sample_3" style="max-height: 350px;"> |
-|----------|-------------|--------|
-| Does the red forklift in warehouse appear on the left side of the brown cardboard boxes stacked? | How close is the man in red hat walking from the wooden pallet with boxes? | Does the man in blue shirt working have a greater height compared to the wooden pallet with boxes on floor? |
-| <think>Okay, let me analyze the layout of the scene to figure this out. The red forklift is clearly visible and it's facing the stack of brown cardboard boxes. The boxes are loaded onto a pallet, and the forklift's forks are inserted under this pallet, indicating that the forklift is preparing to lift or place the boxes...To verify scale and orientation: the yellow safety rails and barriers are on the left side of the boxes. The ladder and wall panels are further left. The forklift is operating from the right-hand side of the image, engaging the pallet head-on...</think> <answer>Correct, the red forklift in the warehouse is not on the left side of the brown cardboard boxes stacked; it is on the right side, actively engaging the boxes from that direction.</answer> | <think>Alright, let me break this down. The man in the red hat is walking in a warehouse aisle, and there's a wooden pallet loaded with boxes right behind him. The pallet is attached to a manual pallet jack, which appears to have been pulled forward...Taking the average stride length of an adult male into account (about 0.75 meters or 75 cm), it looks like the distance from the man's heel to the nearest edge of the pallet is slightly shorter than a full stride. That puts us at just under that 75 cm mark. I'd estimate somewhere around 60 cm is reasonable here, based on visual proximity...</think> <answer>The man in the red hat walking is approximately 60.13 centimeters from the wooden pallet with boxes.</answer> | <think>Let me take a close look at this warehouse scene. The man in the blue shirt is leaning over, reaching toward boxes on a shelf, and there's a pallet with cardboard boxes on the floor near him. To compare their heights, I need to reason about how tall the man would be if he were standing straight, and how tall the pallet is with boxes stacked on top. A standard wooden pallet is about 15 cm (6 inches) tall. The boxes on top add some height, maybe around 30–50 cm depending on their size. Altogether, the total height of the loaded pallet might be roughly 45–65 cm (about 1.5 to 2 feet)...</think> <answer>Indeed, the man in the blue shirt working is taller compared to the wooden pallet with boxes on the floor.</answer> |
-
-  
 ## Models trained using VQASynth 🎹
 
 * [SpaceOm](https://huggingface.co/remyxai/SpaceOm) - the best overall
@@ -52,6 +44,8 @@ Here are some samples from the VQASynth pipeline:
 * [SpaceQwen2.5-VL-3B-Instruct - 3B](https://huggingface.co/remyxai/SpaceQwen2.5-VL-3B-Instruct) - the most popular
 * [SpaceLLaVA - 13B](https://huggingface.co/remyxai/SpaceLLaVA) - the original
 * [SpaceLLaVA - 7B](https://huggingface.co/salma-remyx/spacellava-1.5-7b) - the most interpretable
+
+Examples from [SpaceThinker](https://huggingface.co/remyxai/SpaceThinker-Qwen2.5VL-3B):
 
 | <img src="assets/thinking_example_1.jpg"  alt="sample_1" style="max-height: 350px;" > | <img src="assets/thinking_example_2.png"  alt="sample_2" style="max-height: 350px;"> | <img src="assets/thinking_example_3.png" alt="sample_3" style="max-height: 350px;"> |
 |----------|-------------|--------|
@@ -130,6 +124,8 @@ We've hosted some notebooks visualizing and experimenting with the techniques in
 |----------|-------------|--------|
 | Generate Spatial VQA Dataset | Augment an HF Image Dataset with Spatial VQA | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1sJUsJ5-UR-3Bydgg-thJ59KSNxRG8Q30?usp=sharing) |
 | Spatial Reasoning with Point Clouds | Visualize point clouds and evaluate spatial relationships | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1f3rr-y233GvxWVzPE7_mK-DY52pG0fsm?usp=sharing) |
+| Evaluate SpaceThinker on QSpatial++ | Assess SpaceThinker's quantitative spatial reasoning on the QSpatial++ benchmark | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1buEe2QC4_pnrJwQ9XyRAH7RfaIa6pbex?usp=sharing) |
+| SpaceLLaVA Attention with TransformerLens | Visualize SpaceLLaVA-7B attention patterns using TransformerLens | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/19H_hOL8gc1nFQKpDoioJR8nDWX1lsNZM?usp=sharing) |
 
 ## References
 This project was inspired by or utilizes concepts discussed in the following research paper(s):


### PR DESCRIPTION
## Summary

Three small README changes:

1. **Cut the warehouse-samples table** between *"Here are some samples from the VQASynth pipeline:"* and *"## Models trained using VQASynth"* — redundant with the SpaceThinker examples table directly below.
2. **Add explicit label** above the `thinking_example_*` table so readers can attribute the outputs to a specific model: *"Examples from [SpaceThinker](https://huggingface.co/remyxai/SpaceThinker-Qwen2.5VL-3B):"*.
3. **Add two Colab notebooks** to the Notebooks table:
   - **Evaluate SpaceThinker on QSpatial++** — Assess SpaceThinker's quantitative spatial reasoning on the QSpatial++ benchmark
   - **SpaceLLaVA Attention with TransformerLens** — Visualize SpaceLLaVA-7B attention patterns using TransformerLens

## Changes

`README.md` only — no code changes.

## Test plan

- [ ] README renders correctly on GitHub (tables, images, and Colab-badge links display)
- [ ] Both new Colab links open the intended notebooks