### PR TITLE
chore: relax open3d + onnxruntime pins for Python 3.12 / Colab installs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,14 @@ accelerate==0.34.2
 numpy==1.26.4
 timm==1.0.9
 einops==0.7.0
-open3d==0.18.0
+open3d>=0.18.0,<0.20.0
 opencv-python==4.8.1.78
 tqdm==4.66.3
 matplotlib==3.6.2
 transformers==4.48.0
 huggingface-hub==0.25.1
 onnx==1.21.0
-onnxruntime==1.15.1
+onnxruntime>=1.18.1,<2.0
 scipy==1.12.0
 openai==2.24.0
 litellm==1.84.0


### PR DESCRIPTION
Two exact-version pins have been the source of manual `sed` steps in every
Colab install (surfaced repeatedly during PR #115 testing):

- `open3d==0.18.0` → no Python 3.12 wheels; 0.19.0 added 3.12 support
- `onnxruntime==1.15.1` → also has a 3.12 wheel gap plus lags several security patches behind `onnxruntime-gpu` (which is already at 1.18.1)

## Changes

```diff
-open3d==0.18.0
+open3d>=0.18.0,<0.20.0
-onnxruntime==1.15.1
+onnxruntime>=1.18.1,<2.0
```

- **open3d**: floor preserved, ceiling below the 0.20 API-change cutoff to keep point-cloud + visualization surfaces stable
- **onnxruntime**: floor bumped to match `onnxruntime-gpu` (fixes the CPU/GPU version skew introduced by the recent security-bump cadence in #109-#112), ceiling below the 2.0 major

Both are floors-preserved (no downgrade path), ceilings kept inside their respective major-version API-stability windows.

## Motivation

Eliminates the `clone → sed → install` ritual that Colab-3.12 users hit today. From the PR-115 review Colab notebook:

```python
# no longer needed after this PR:
!sed -i 's/open3d==0.18.0/open3d/g' setup.py requirements.txt
!sed -i 's/onnxruntime==1.15.1/onnxruntime/g' setup.py requirements.txt
```

## Not in scope

Every other dep in `requirements.txt` is also `==` pinned. Leaving them alone here — this PR is targeted at the two specific pins that block Python-3.12 installs. Broader unpinning would be a separate conversation about the project's pinning policy overall (reproducibility vs. install ergonomics).