### PR TITLE
docs(readme): refresh Agent with VQASynth Tools section for the expanded inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,11 @@ We've hosted some notebooks visualizing and experimenting with the techniques in
 
 ## Agent with VQASynth Tools
 
-The VQASynth tool inventory — Florence-2 detection/OCR, DepthPro/VGGT metric depth, 3D distance measurement — is also exposed as an [NOOA](https://github.com/NVIDIA-NeMo/labs-OO-Agents)-based agent (`experiments/nooa_agent/`) that composes tool calls dynamically per prompt rather than following a pre-templated pipeline. Useful when the input question isn't known at pipeline-design time.
+The VQASynth tool inventory — Florence-2 detection + segmentation, DepthPro/VGGT/FoundationGeo metric depth, [Orient-Anything](https://github.com/SpatialVision/Orient-Anything) object orientation, [NVIDIA DAM](https://github.com/NVlabs/describe-anything) regional captioning, [MediaPipe](https://github.com/google/mediapipe) pose keypoints, open3d 3D bounding boxes, and OpenCV multi-view correspondence — is exposed as an [NOOA](https://github.com/NVIDIA-NeMo/labs-OO-Agents)-based agent (`experiments/nooa_agent/`) that composes tool calls dynamically per prompt rather than following a pre-templated pipeline. Useful when the input question isn't known at pipeline-design time.
 
-- **Dynamic tool composition** — the LLM decides which tools to call and in what order per question. `detect_objects → metric_depth → distance_3d` for a "how far apart" query; `caption_scene → dense_region_captions` for a scene inventory. No pre-coded question types.
+![Dynamic pipeline construction across all NOOA agent tools](https://gist.githubusercontent.com/smellslikeml/65da53b4a9d7224e991cb88bc33a7e5e/raw/q5_full_spatial_report.png)
+
+- **Dynamic tool composition** — the LLM decides which tools to call and in what order per question. `detect_objects → metric_depth → distance_3d` for a "how far apart" query; `detect_objects → segment → orient → describe_region` for camera-facing object descriptions; `find_correspondences → depth → detect_3d_boxes` for cross-view scene diffs. No pre-coded question types.
 - **Dense reward annotation** — plug into a robot-learning pipeline as a per-frame reward or CoT source. The agent satisfies [`lerobot`](https://github.com/huggingface/lerobot)'s `VlmClient` protocol via `SpatialAnnotatorVlmClient`, so it drops into any annotation module (VQA, plan, ECoT) as a tool-grounded alternative to a raw VLM call.
 - **Traces grounded on tool calls** — every `annotate()` streams a JSONL row in OpenAI-messages format (ready for Qwen2.5-VL / Qwen3-VL fine-tuning) preserving the full tool-call chain, not just the final answer. Reasoning stays auditable.
 


### PR DESCRIPTION
## Summary

Refreshes the ## Agent with VQASynth Tools README section to reflect the seven tool modules that landed today (PRs #121, #123, #125-#132, #134-#138):

- **Tool-inventory sentence** — extends from *"Florence-2, DepthPro/VGGT, 3D distance"* to name every current module (Florence-2 detect+segment, DepthPro/VGGT/FoundationGeo, Orient-Anything, NVIDIA DAM, MediaPipe pose, open3d 3D boxes, OpenCV correspondence) with links to each upstream repo.
- **"Dynamic Pipeline Construction: 8 Tool Modules" diagram** dropped in right under the intro paragraph — shows the full NOOA tool inventory composed at agent-runtime into one structured report. Hosted on a gist raw URL so nothing lands in the repo tree.
- **Two extra example chains** added to the "Dynamic tool composition" bullet — camera-facing description (`detect → segment → orient → describe_region`) and cross-view diff (`find_correspondences → depth → detect_3d_boxes`) — so the prose matches what the diagram shows.

## Test plan
- [x] Rendered locally — image resolves + inline layout reads cleanly
- [x] Every mentioned tool (`orient`, `describe_region`, `pose_keypoints`, `detect_3d_boxes`, `find_correspondences`) exists in `experiments/nooa_agent/tools/` on `main` after today's merges
- [x] Diagram source: https://gist.github.com/smellslikeml/65da53b4a9d7224e991cb88bc33a7e5e (see for the four other composition-pattern illustrations)