### PR TITLE
NOOA tool: surface normals from DepthResult point clouds

### DIFF
--- a/experiments/nooa_agent/tests/test_surface_normals_tool.py
+++ b/experiments/nooa_agent/tests/test_surface_normals_tool.py
@@ -1,0 +1,178 @@
+"""Structural tests for the NOOA surface-normals tool wrapper.
+
+Mirrors ``test_orientation_tool.py``'s philosophy: verify the normal
+derivation + facing/angle prose against synthetic geometry, with no GPU, no
+model download, and no torch import. The integration anchor is the existing
+``experiments.nooa_agent.tools.depth`` module — fixtures build a real
+:class:`DepthResult` and (for the frontal-plane case) unproject it through
+the *pre-existing* ``_unproject`` helper, so this is not a self-test of the
+new file alone: if the DepthResult contract or the unprojection geometry
+changes, these normals move with it.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+# Pre-existing depth module — exercised here so the test isn't a self-test of
+# only the new surface_normals code. _unproject is the same geometry the depth
+# tool uses internally, so the frontal-plane fixture flows through the real
+# DepthResult → point-cloud → normals path the agent would hit.
+from experiments.nooa_agent.tools.depth import DepthResult, _unproject
+from experiments.nooa_agent.tools.surface_normals import (
+    NormalResult,
+    normal_at_pixel,
+    surface_angle,
+    surface_facing,
+    surface_normals,
+)
+
+
+def _depth_result(xyz, *, backend="depthpro"):
+    """Bundle a point cloud into a DepthResult the way depth.py's backends do."""
+    H, W = xyz.shape[:2]
+    focal = 100.0
+    K = np.array([[focal, 0, W / 2], [0, focal, H / 2], [0, 0, 1]], dtype=np.float32)
+    return DepthResult(
+        depth_m=np.full((H, W), 5.0, dtype=np.float32),
+        focal_px=focal,
+        intrinsics_3x3=K,
+        point_cloud_xyz=xyz.astype(np.float32),
+        backend=backend,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: DepthResult (existing module) → surface_normals → normals
+# ---------------------------------------------------------------------------
+def test_frontal_plane_normals_face_camera_via_real_unproject():
+    # Frontal plane: constant depth. Unproject through depth.py's OWN helper so
+    # the fixture isn't a parallel reimplementation of the geometry.
+    H, W = 16, 20
+    focal = 100.0
+    K = np.array([[focal, 0, W / 2], [0, focal, H / 2], [0, 0, 1]], dtype=np.float32)
+    depth_m = np.full((H, W), 5.0, dtype=np.float32)
+    dr = DepthResult(
+        depth_m=depth_m,
+        focal_px=focal,
+        intrinsics_3x3=K,
+        point_cloud_xyz=_unproject(depth_m, K),
+        backend="vggt",
+    )
+
+    result = surface_normals(dr)
+
+    assert isinstance(result, NormalResult)
+    assert result.normals_xyz.shape == (H, W, 3)
+    # Metric3Dv2 convention: viewer-facing surface → normal ≈ (0, 0, -1).
+    sample = result.normals_xyz[H // 2, W // 2]
+    np.testing.assert_allclose(sample, [0.0, 0.0, -1.0], atol=1e-4)
+    # Every interior pixel is unit-length and camera-facing.
+    interior = result.normals_xyz[1:-1, 1:-1]
+    norms = np.linalg.norm(interior, axis=-1)
+    np.testing.assert_allclose(norms, 1.0, atol=1e-4)
+    assert result.backend == "vggt+pointcloud_normals"
+
+
+def test_floor_plane_normals_face_upward():
+    # Hand-built point cloud for a horizontal surface: x increases right, z
+    # decreases down-pixel, y held constant → normal (0, -1, 0) = faces up.
+    H, W = 10, 12
+    i, j = np.meshgrid(np.arange(H), np.arange(W), indexing="ij")
+    xyz = np.stack([j.astype(np.float32), np.zeros_like(j, dtype=np.float32),
+                    -i.astype(np.float32)], axis=-1)
+    dr = _depth_result(xyz, backend="depthpro")
+
+    result = surface_normals(dr, smooth=0)  # raw cross product — synthetic input
+    sample = result.normals_xyz[H // 2, W // 2]
+    np.testing.assert_allclose(sample, [0.0, -1.0, 0.0], atol=1e-4)
+    assert surface_facing(sample) == "faces upward"
+
+
+def test_surface_normals_unprojects_when_pointcloud_missing():
+    # DepthPro-style DepthResult carries no point cloud; surface_normals must
+    # fall back to _unproject(depth_m, K) and still produce camera-facing normals.
+    H, W = 8, 8
+    focal = 80.0
+    K = np.array([[focal, 0, W / 2], [0, focal, H / 2], [0, 0, 1]], dtype=np.float32)
+    dr = DepthResult(
+        depth_m=np.full((H, W), 3.0, dtype=np.float32),
+        focal_px=focal,
+        intrinsics_3x3=K,
+        point_cloud_xyz=None,
+        backend="depthpro",
+    )
+    result = surface_normals(dr)
+    np.testing.assert_allclose(result.normals_xyz[H // 2, W // 2], [0, 0, -1.0], atol=1e-4)
+    assert result.backend == "depthpro+pointcloud_normals"
+
+
+# ---------------------------------------------------------------------------
+# normal_at_pixel — same x=col / y=row convention as depth_at_point
+# ---------------------------------------------------------------------------
+def test_normal_at_pixel_clips_and_samples():
+    H, W = 6, 7
+    xyz = np.stack(
+        [np.full((H, W), 0.5), np.zeros((H, W)), np.full((H, W), 4.0)], axis=-1
+    ).astype(np.float32)
+    result = surface_normals(_depth_result(xyz), smooth=0)
+    # Out-of-bounds coords clip to the corner, not raise.
+    n = normal_at_pixel(result, x=-100, y=9999)
+    assert n.shape == (3,)
+    # x=col / y=row: column 0 + constant-x cloud → finite sample returned.
+    assert np.isfinite(n).all()
+
+
+# ---------------------------------------------------------------------------
+# surface_facing — deterministic prose mapping (unit-tested in isolation)
+# ---------------------------------------------------------------------------
+def test_surface_facing_buckets_each_axis():
+    assert surface_facing(np.array([0.0, 0.0, -1.0])) == "faces the camera"
+    assert surface_facing(np.array([0.0, 0.0, 1.0])) == "faces away from the camera"
+    assert surface_facing(np.array([0.0, -1.0, 0.0])) == "faces upward"
+    assert surface_facing(np.array([0.0, 1.0, 0.0])) == "faces downward"
+    assert surface_facing(np.array([-1.0, 0.0, 0.0])) == "faces left"
+    assert surface_facing(np.array([1.0, 0.0, 0.0])) == "faces right"
+
+
+def test_surface_facing_handles_degenerate_input():
+    assert surface_facing(np.zeros(3)) == "unknown surface"
+    assert surface_facing(np.array([np.nan, 0.0, 0.0])) == "unknown surface"
+    # Magnitude is ignored — direction is what matters.
+    assert surface_facing(np.array([0.0, 0.0, -7.5])) == "faces the camera"
+
+
+# ---------------------------------------------------------------------------
+# surface_angle — parallel / anti-parallel, the "resting flat" signal
+# ---------------------------------------------------------------------------
+def test_surface_angle_parallel_and_antiparallel():
+    up = np.array([0.0, -1.0, 0.0])
+    flat = surface_angle(up, up)
+    assert flat["angle_deg"] == 0.0
+    assert flat["parallel"] is True
+    assert flat["anti_parallel"] is False
+    assert "parallel" in flat["relation"]
+
+    # Tabletop faces up (0,-1,0); an object resting on it has its bottom face
+    # pointing down (0,1,0) → normals anti-parallel → "resting flush".
+    resting = surface_angle(np.array([0.0, -1.0, 0.0]), np.array([0.0, 1.0, 0.0]))
+    assert resting["angle_deg"] == 180.0
+    assert resting["anti_parallel"] is True
+    assert "flush" in resting["relation"]
+
+
+def test_surface_angle_orthogonal_is_in_between():
+    d = surface_angle(np.array([0.0, 0.0, -1.0]), np.array([1.0, 0.0, 0.0]))
+    assert 80.0 <= d["angle_deg"] <= 100.0
+    assert d["parallel"] is False and d["anti_parallel"] is False
+
+
+# ---------------------------------------------------------------------------
+# NormalResult.__repr__ — compact, mirrors DepthResult.__repr__'s guard
+# ---------------------------------------------------------------------------
+def test_normal_result_repr_is_compact():
+    r = NormalResult(normals_xyz=np.zeros((8, 8, 3), dtype=np.float32), backend="x")
+    text = repr(r)
+    assert len(text) < 120
+    assert "pointcloud_normals" not in text  # full array must NOT be dumped
+    assert "NormalResult" in text
+    assert "\n" not in text

--- a/experiments/nooa_agent/tools/surface_normals.py
+++ b/experiments/nooa_agent/tools/surface_normals.py
@@ -1,0 +1,246 @@
+"""Per-pixel surface normals derived from a metric depth result.
+
+Metric3D v2 (arXiv:2404.15506) showed that jointly estimating metric depth
+*and* surface normals from a single image is the key to metric 3D recovery —
+depth and normals are complementary geometric signals, and the normal head is
+what disambiguates surface orientation that pure depth can't express. The
+NOOA depth backends (DepthPro / VGGT / FoundationGeo in
+:mod:`experiments.nooa_agent.tools.depth`) already produce a metric point
+cloud on ``DepthResult.point_cloud_xyz`` but do NOT expose surface normals.
+This module fills exactly that gap: it derives per-pixel surface normals from
+the existing point cloud by local tangent-plane fitting, so the orientation /
+3D-understanding tools can consume normals without a new model download or a
+weight host.
+
+**Adapted port (Mode 2).** The paper's *learned* per-pixel normal head is
+substituted here with a parameter-free finite-difference estimate over the
+depth backend's own point cloud. The metric depth itself is reused unchanged
+from whichever backend produced the ``DepthResult`` — only the normal head is
+proxied. Substitutions, explicitly: learned normal head → point-cloud
+tangent-plane cross product; Metric3Dv2's metric-depth transformer → the
+repo's existing DepthPro/VGGT/FoundationGeo backends; Metric3Dv2's CUDA
+inference + NYU/KITTI benchmark suite → cut (evaluation belongs downstream).
+The joint depth+normal signal — Metric3Dv2's actual contribution — is what's
+delivered, on the surface the repo already has.
+
+Frame convention (matches Metric3Dv2's "normal points toward the camera"):
+the depth frame is x→right, y→down, z→away-from-camera. A surface facing the
+viewer therefore has normal ≈ (0, 0, -1); a tabletop / floor facing up has
+normal ≈ (0, -1, 0).
+
+Pure-numpy — importing this module pulls in neither torch nor transformers,
+so it stays importable on the NOOA test host without CUDA or weights (same
+discipline as :mod:`experiments.nooa_agent.tools.depth`).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# DepthResult is the uniform depth-tool contract this module consumes; _unproject
+# is reused (not reimplemented) so a DepthResult whose backend skipped the point
+# cloud still gets normals through the same geometry depth.py uses.
+from experiments.nooa_agent.tools.depth import DepthResult, _unproject
+
+
+@dataclass
+class NormalResult:
+    """Per-pixel surface normals derived from a :class:`DepthResult`.
+
+    Fields:
+        normals_xyz: ``(H, W, 3)`` float32 unit-norm surface normals in the
+            depth camera frame (x→right, y→down, z→away-from-camera). Points
+            toward the camera (Metric3Dv2 convention): a viewer-facing surface
+            has normal ≈ (0, 0, -1). Pixels whose source point cloud was
+            non-finite carry a zero vector — check ``np.linalg.norm > 0``
+            before trusting a sample.
+        backend: the depth backend the normals were derived from, suffixed
+            with ``+pointcloud_normals`` so consumers can tell this is the
+            derived proxy, not a learned head (e.g. ``"vggt+pointcloud_normals"``).
+        confidence: reserved for a future learned normal head. The
+            finite-difference proxy leaves this ``None``.
+    """
+
+    normals_xyz: np.ndarray
+    backend: str
+    confidence: np.ndarray | None = None
+
+    def __repr__(self) -> str:
+        # Compact one-liner — mirrors DepthResult.__repr__'s guard against
+        # dumping the full (H, W, 3) array into a NOOA trace event (one fires
+        # per tool call). Full normals remain accessible via ``normals_xyz``.
+        H, W = self.normals_xyz.shape[:2]
+        return (
+            f"NormalResult(backend={self.backend!r}, shape=({H}, {W}), "
+            f"has_confidence={self.confidence is not None})"
+        )
+
+
+def _unit(vecs: np.ndarray) -> np.ndarray:
+    """Normalize the last axis; leave zero/NaN vectors as zeros (not NaN)."""
+    norms = np.linalg.norm(vecs, axis=-1, keepdims=True)
+    safe = np.where((norms > 1e-12) & np.isfinite(norms), norms, 1.0)
+    out = vecs / safe
+    # Rows that were zero or non-finite stay zero rather than silently unitizing.
+    out = np.where((norms > 1e-12) & np.isfinite(norms), out, 0.0)
+    return out
+
+
+def _normals_from_pointcloud(xyz: np.ndarray, smooth: int = 1) -> np.ndarray:
+    """Per-pixel unit normals via the local tangent-plane cross product.
+
+    Tangents are finite differences in the +u (right) and +v (down) pixel
+    directions, with a backward difference at the trailing row/column so every
+    pixel has a valid tangent. ``normal = cross(dv, du)`` so a viewer-facing
+    frontal plane yields ``(0, 0, -1)`` (toward camera) — the Metric3Dv2
+    convention.
+
+    ``smooth`` (≥0) repeats a 3×3 vector-average + renormalize that many
+    times. Learned normals (Metric3Dv2) are smooth; raw cross products over a
+    real depth map are noisy, so a single pass is the default. 0 keeps the raw
+    cross product (useful for synthetic / noise-free inputs).
+    """
+    du = np.zeros_like(xyz)
+    du[:, :-1] = xyz[:, 1:] - xyz[:, :-1]
+    du[:, -1] = xyz[:, -1] - xyz[:, -2]
+    dv = np.zeros_like(xyz)
+    dv[:-1, :] = xyz[1:, :] - xyz[:-1, :]
+    dv[-1, :] = xyz[-1, :] - xyz[-2, :]
+
+    normals = np.cross(dv, du)  # → (0,0,-1) on a viewer-facing frontal plane
+    normals = _unit(normals)
+
+    for _ in range(max(0, smooth)):
+        # 3×3 box average on each component, then renormalize. np.pad with
+        # edge keeps the grid size fixed and avoids shrinking toward the
+        # border. NaNs (from non-finite source points) are excluded from the
+        # mean so they don't poison neighbors.
+        padded = np.pad(normals, ((1, 1), (1, 1), (0, 0)), mode="edge")
+        acc = np.zeros_like(normals)
+        count = np.zeros(normals.shape[:2] + (1,), dtype=np.float32)
+        for di in range(3):
+            for dj in range(3):
+                win = padded[di : di + normals.shape[0], dj : dj + normals.shape[1]]
+                finite = np.isfinite(win).all(axis=-1, keepdims=True)
+                acc += np.where(finite, win, 0.0)
+                count += finite.astype(np.float32)
+        count = np.where(count > 0, count, 1.0)
+        normals = _unit(acc / count)
+
+    # Pixels whose source point was non-finite carry no real surface — zero
+    # them so a downstream sample there is detectable rather than a spurious
+    # unit vector.
+    bad = ~np.isfinite(xyz).all(axis=-1)
+    if bad.any():
+        normals[bad] = 0.0
+    return normals.astype(np.float32)
+
+
+def surface_normals(depth: DepthResult, *, smooth: int = 1) -> NormalResult:
+    """Derive per-pixel surface normals from a :class:`DepthResult`.
+
+    Uses ``depth.point_cloud_xyz`` when the backend populated it (DepthPro
+    unprojects; VGGT/FoundationGeo carry metric points directly); falls back
+    to unprojecting ``depth.depth_m`` with ``depth.intrinsics_3x3`` otherwise
+    — the same geometry :func:`distance_3d_meters` uses, so normals stay
+    consistent with the 3D distances the agent already reasons over.
+
+    Args:
+        depth: a :class:`DepthResult` from any depth-tool backend.
+        smooth: number of 3×3 vector-average smoothing passes (default 1).
+            0 keeps raw cross-product normals.
+
+    Returns:
+        :class:`NormalResult` tagged ``"<backend>+pointcloud_normals"``.
+    """
+    xyz = depth.point_cloud_xyz
+    if xyz is None:
+        xyz = _unproject(depth.depth_m, depth.intrinsics_3x3)
+    normals = _normals_from_pointcloud(np.asarray(xyz, dtype=np.float32), smooth=smooth)
+    return NormalResult(
+        normals_xyz=normals,
+        backend=f"{depth.backend}+pointcloud_normals",
+    )
+
+
+def normal_at_pixel(normals: NormalResult | np.ndarray, x: float, y: float) -> np.ndarray:
+    """Sample the surface normal at a pixel (nearest, clipped to bounds).
+
+    Mirrors :func:`depth_at_point`'s convention (x = column, y = row) so the
+    agent can hand it the same box-centroid coordinates it already uses for
+    depth sampling.
+    """
+    arr = normals.normals_xyz if isinstance(normals, NormalResult) else normals
+    H, W = arr.shape[:2]
+    xi = max(0, min(W - 1, int(round(x))))
+    yi = max(0, min(H - 1, int(round(y))))
+    return arr[yi, xi].astype(np.float32)
+
+
+def surface_facing(normal: np.ndarray) -> str:
+    """Natural-language facing for a single surface normal (pure function).
+
+    Buckets by the dominant axis so the agent gets something quotable
+    ("faces the camera", "faces upward") instead of a bare vector — the
+    normal-head analog of :func:`orientation._describe_orientation`. The raw
+    vector stays on :class:`NormalResult`; this string exists for prose.
+
+    A zero / non-finite normal (e.g. sampled off a non-finite depth pixel)
+    returns ``"unknown surface"``.
+    """
+    n = np.asarray(normal, dtype=np.float32).reshape(-1)
+    if n.shape != (3,) or not np.isfinite(n).all() or np.linalg.norm(n) < 1e-6:
+        return "unknown surface"
+    n = n / np.linalg.norm(n)
+    ax, ay, az = abs(n)
+    if az >= ay and az >= ax:
+        return "faces the camera" if n[2] < 0 else "faces away from the camera"
+    if ay >= ax:
+        return "faces upward" if n[1] < 0 else "faces downward"
+    return "faces left" if n[0] < 0 else "faces right"
+
+
+def surface_angle(a: np.ndarray, b: np.ndarray) -> dict:
+    """Angle between two surface normals (pure function).
+
+    Use after sampling two normals (e.g. an object's contact face vs. the
+    surface it rests on) to ground "is it lying flat?" in real geometry
+    instead of guessing — the surface analog of :func:`orientation_delta`.
+    Anti-parallel normals (≈180°) mean two faces meet flush (an object
+    resting flat on a tabletop); parallel normals (≈0°) face the same way.
+
+    Args:
+        a, b: ``(3,)`` surface normals (any magnitude; unit-normalized internally).
+
+    Returns:
+        Dict with ``angle_deg`` (0..180), ``parallel`` / ``anti_parallel``
+        flags, and a ``relation`` summary the agent can quote.
+    """
+    na = _unit(np.asarray(a, dtype=np.float32).reshape(-1))
+    nb = _unit(np.asarray(b, dtype=np.float32).reshape(-1))
+    cos = float(np.clip(np.dot(na, nb), -1.0, 1.0))
+    angle = float(np.degrees(np.arccos(cos)))
+    parallel = angle < 25.0
+    anti_parallel = angle > 155.0
+    if parallel:
+        relation = "parallel — surfaces face the same way"
+    elif anti_parallel:
+        relation = "anti-parallel — faces meet flush (e.g. an object resting flat)"
+    else:
+        relation = f"tilted ~{angle:.0f}° apart"
+    return {
+        "angle_deg": round(angle, 1),
+        "parallel": parallel,
+        "anti_parallel": anti_parallel,
+        "relation": relation,
+    }
+
+
+__all__ = [
+    "NormalResult",
+    "surface_normals",
+    "normal_at_pixel",
+    "surface_facing",
+    "surface_angle",
+]


### PR DESCRIPTION
## Adapted port of Metric3Dv2 surface-normal head

Consumes existing `DepthResult` point clouds (DepthPro / VGGT / FoundationGeo) and derives per-pixel surface normals via local tangent-plane cross product — the parameter-free proxy for [Metric3Dv2](https://arxiv.org/abs/2404.15506)'s learned normal head. Metric depth reused unchanged from whichever backend produced the `DepthResult`; only the normal head is proxied.

**Files:** 2
- `experiments/nooa_agent/tools/surface_normals.py` (+246)
- `experiments/nooa_agent/tests/test_surface_normals_tool.py` (+178)

**Third iteration** of the metric3dv2 exploration in this repo:
- **v1** (Aug 2): added a full Metric3D depth backend + depth-tool changes + normals (~473 LOC)
- **v2** (Aug 9): pared to a standalone surface-normals tool, dropped the depth backend (~515 LOC)
- **v3** (this PR, Aug 10): further pared to consume the existing `DepthResult` contract without shipping a new model dependency (~424 LOC)

Sibling branches `metric3dv2-a-versatile-monocular-geometric-foundation-model-` (v1) and `--v2` are superseded on merge.

## API mirrors adjacent tools

- `NormalResult` dataclass — shape and `__repr__` guard follow `DepthResult` (avoids dumping full arrays into NOOA trace events)
- `surface_normals(depth, *, smooth=1)` — consumes `DepthResult`, returns `NormalResult` tagged `"<backend>+pointcloud_normals"` so the derived-proxy nature is visible to downstream consumers
- `normal_at_pixel(x, y)` — same `x=col, y=row` convention as `depth_at_point`, so agent can reuse box-centroid coordinates
- `surface_facing(normal)` — prose helper (analog of `orientation._describe_orientation`)
- `surface_angle(a, b)` — parallel / anti-parallel / tilted classification (analog of `orientation_delta`); the "object resting flush on tabletop" signal

## Substitutions (Mode-2 adapted port)

Documented explicitly in the module docstring:
- learned normal head → point-cloud tangent-plane cross product
- Metric3Dv2's metric-depth transformer → repo's existing DepthPro / VGGT / FoundationGeo backends
- Metric3Dv2's CUDA inference + NYU/KITTI benchmark suite → cut (evaluation belongs downstream)

The joint depth+normal signal — Metric3Dv2's actual contribution — is delivered, on infrastructure the repo already has.

## Tests

Pure numpy, no cv2 / torch / transformers imports. Fast, always runnable — matches the "importable on the NOOA test host without CUDA or weights" discipline from the existing `depth.py`. Integration-anchored via `_unproject` from `experiments.nooa_agent.tools.depth`, so the frontal-plane fixture flows through the real DepthResult → point-cloud → normals path.

Coverage:
- Frontal plane via real `_unproject` → normal ≈ (0, 0, -1)
- Floor plane → (0, -1, 0), `surface_facing` returns "faces upward"
- Missing point cloud → falls back to `_unproject(depth_m, K)`, correct normals
- `normal_at_pixel` coord clipping + convention
- `surface_facing` — all 6 axis buckets + degenerate (zero, NaN) inputs
- `surface_angle` — parallel, anti-parallel (flush), orthogonal
- `NormalResult.__repr__` compact + no full-array dump

## License

Metric3Dv2 upstream ([YvanYin/Metric3D](https://github.com/YvanYin/Metric3D), BSD 2-Clause) — no code from that repo is vendored. Surface-normals derivation implemented independently in numpy over existing depth-tool outputs.

**Implementation by**: Claude Code via Remyx Outrider daily workflow (branch-mode), promoted to PR after review.